### PR TITLE
Updated target with death state, flocking, and round progression

### DIFF
--- a/80s Game/Assets/Scripts/KinematicSteer.cs
+++ b/80s Game/Assets/Scripts/KinematicSteer.cs
@@ -47,8 +47,8 @@ public class KinematicSteer : MonoBehaviour
 
         // Incorporate flocking behavior in final velocity
         velocity += Separate(TargetManager.targets);
-        //velocity += Alignment(TargetManager.targets);
-        //velocity += Cohesion(TargetManager.targets);
+        velocity += Alignment(TargetManager.targets);
+        velocity += Cohesion(TargetManager.targets);
 
         // Get new position
         float newPosX = transform.position.x + velocity.x * Time.deltaTime;
@@ -67,7 +67,7 @@ public class KinematicSteer : MonoBehaviour
 
         // Get a random range for x and y levels
         float newPosX = Random.Range(-maxWidth, maxWidth);
-        float newPosY = Random.Range(-maxHeight/2, maxHeight/2);
+        float newPosY = Random.Range(-maxHeight, maxHeight);
 
         // Set the new position
         targetPosition = new Vector3(newPosX, newPosY, transform.position.z);
@@ -143,8 +143,11 @@ public class KinematicSteer : MonoBehaviour
     // Method for Cohesion
     public Vector2 Cohesion(Target[] neighbors)
     {
+        // Initialize to default zero vector
+        Vector3 desiredVelocity = Vector3.zero;
         Vector3 centroid = Vector3.zero;
-        int count = 0;
+
+        int neighborCount = 0;
 
         // Get the sum of all points of neighbors within a radius of 7
         foreach (Target neighbor in neighbors)
@@ -152,14 +155,19 @@ public class KinematicSteer : MonoBehaviour
             if (Vector3.Distance(transform.position, neighbor.transform.position) < 7)
             {
                 centroid += neighbor.transform.position;
-                count++;
+                neighborCount++;
             }
         }
 
         // Divide by number of neighbors to get the average point
-        centroid /= count;
+        centroid /= neighborCount;
+
+        // Calculate the desired velocity
+        desiredVelocity = centroid - transform.position;
+        desiredVelocity.Normalize();
+        desiredVelocity *= maxSpeed;
 
         // Seek that average point AKA the Centroid
-        return centroid * 0.2f;
+        return desiredVelocity * 0.1f;
     }
 }

--- a/80s Game/Assets/Scripts/TargetManager.cs
+++ b/80s Game/Assets/Scripts/TargetManager.cs
@@ -10,8 +10,10 @@ public class TargetManager : MonoBehaviour
 
     // Default values
     public int firstRoundTargetCount = 5;
-    int currentRound = 1;
-    int currentRoundSize;
+    public int currentRound = 1;
+    public int currentRoundSize;
+    public int numStuns = 0;
+    int maxTargetsOnScreen = 8;
 
     // Start is called before the first frame update
     void Start()
@@ -44,17 +46,37 @@ public class TargetManager : MonoBehaviour
     }
 
     // Method for updating round parameters
-    void UpdateRoundParameters()
+    public void UpdateRoundParameters()
     {
-        // TO-DO
-        // When we get to future rounds
+        // Reset stuns and update round counter
+        currentRound++;
+        numStuns = 0;
+
+        // Update round size and arena max
+        currentRoundSize += 2;
+        maxTargetsOnScreen += 1;
+        if (maxTargetsOnScreen >= targets.Length)
+        {
+            maxTargetsOnScreen = targets.Length - 2;
+        }
     }
 
     // Method for starting the next round
-    void StartNextRound()
+    public void StartNextRound()
     {
-        // TO-DO
-        // When we get to future rounds
+        // Check list isn't empty
+        if (targets.Length > 0)
+        {
+            // Iterate through and spawn the next set of targets
+            for (int i = 0; i < currentRoundSize; i++)
+            {
+                int targetIndex = GetNextAvailableTarget();
+                if (targetIndex >= 0)
+                {
+                    SpawnTarget(targetIndex);
+                }
+            }
+        }
     }
 
     // Method for spawning more targets if needed
@@ -73,6 +95,7 @@ public class TargetManager : MonoBehaviour
 
         // Update on-screen status
         targets[targetIndex].isOnScreen = true;
+        targets[targetIndex].currentState = TargetStates.Moving;
     }
 
     // Method for getting all targets currently on screen


### PR DESCRIPTION
**Summary of What is Being added**
- Targets now have Reset() method used for setting back defaults and stashing away until ready for use again
- Target Manager now progresses up to 4 rounds with a higher number of targets spawning each time
- Targets now move with flocking behavior, but values are currently more chaotic than typical flocks

**Please Describe How to test**
Open the main level scene and press play. Click on targets as they spawn in and play-through as you would expect.

**Can This be Tested with mouse input**
Yes

**What Sprint is this Due in?**
Sprint 2