### PR TITLE
Set target cap to 10 in manager and added target flee behavior

### DIFF
--- a/80s Game/Assets/Scripts/KinematicSteer.cs
+++ b/80s Game/Assets/Scripts/KinematicSteer.cs
@@ -8,6 +8,7 @@ public class KinematicSteer : MonoBehaviour
     public Vector2 targetPosition;
     public float targetRadius;
     public bool canMove;
+    public bool isFleeing;
 
     // Maximums
     [Range(0, 10)]
@@ -51,12 +52,8 @@ public class KinematicSteer : MonoBehaviour
         // Only steer if agent is currently moveable
         if (canMove)
         {
-            // Get the direction towards target position
-            Vector2 direction = targetPosition - new Vector2(transform.position.x, transform.position.y);
-            float distance = direction.magnitude;
-
-            // Stop moving if at destination
-            if (distance <= targetRadius)
+            // Check if target reaches destination in wander state
+            if (IsAtDestination() && !isFleeing)
             {
                 // Find new position once at destination
                 SetWanderPosition();
@@ -110,6 +107,13 @@ public class KinematicSteer : MonoBehaviour
         return steer;
     }
 
+    // Method for setting the target position
+    public void SetTargetPosition(Vector2 newTarget)
+    {
+        // Set the position
+        targetPosition = newTarget;
+    }
+
     // Method used for Wandering
     public void SetWanderPosition()
     {
@@ -122,7 +126,18 @@ public class KinematicSteer : MonoBehaviour
         float newPosY = Random.Range(-maxHeight + spriteRenderer.size.y, maxHeight - spriteRenderer.size.y);
 
         // Set the new position
-        targetPosition = new Vector2(newPosX, newPosY);
+        SetTargetPosition(new Vector2(newPosX, newPosY));
+    }
+
+    // Method for checking if target has arrived at destination
+    public bool IsAtDestination()
+    {
+        // Get the direction towards target position
+        Vector2 direction = targetPosition - new Vector2(transform.position.x, transform.position.y);
+        float distance = direction.magnitude;
+
+        // Return result
+        return distance <= targetRadius;
     }
 
     // Method for applying flocking

--- a/80s Game/Assets/Scripts/Target.cs
+++ b/80s Game/Assets/Scripts/Target.cs
@@ -17,6 +17,11 @@ public class Target : MonoBehaviour
     public bool isOnScreen = false;
     public int pointValue = 1000;
 
+    // Fleeing fields
+    public float timeUntilFlee = 5.0f;
+    float fleeTimer = 0.0f;
+    public Vector2 fleeLocation;
+
     // Get component for player interactions
     InputManager inputManager;
 
@@ -33,6 +38,9 @@ public class Target : MonoBehaviour
         movementControls = GetComponent<KinematicSteer>();
         inputManager = GameManager.Instance.InputManager;
         spawnPoint = transform.position;
+
+        // Init flee timer
+        fleeTimer = timeUntilFlee;
     }
 
     // Update is called once per frame
@@ -48,23 +56,31 @@ public class Target : MonoBehaviour
                 // Handle all base target movement here
                 case TargetStates.Moving:
                     // Enable movement
+                    movementControls.isFleeing = false;
                     movementControls.canMove = true;
 
-                    // Check for player input coords hitting target
-                    Vector3 shotPos = inputManager.MouseWorldPosition;
-                    RaycastHit2D hit = Physics2D.Raycast(shotPos, Vector2.zero);
-                    if (hit && inputManager.MouseLeftDownThisFrame && Time.timeScale > 0) // Check time scale so bats cant be harmed while game is paused
+                    // Update flee timer
+                    fleeTimer -= Time.deltaTime;
+                    if(fleeTimer <= 0.0f) // When timer is up, set target to flee
                     {
-                        // Check that hit has detected this particular object
-                        if(hit.collider.gameObject == gameObject)
-                        {
-                            currentState = TargetStates.Death;
-                        }
+                        currentState = TargetStates.Fleeing;
+                        movementControls.SetTargetPosition(fleeLocation);
                     }
+
+                    // Check for stun
+                    DetectStun();
                     break;
 
                 // Handle fleeing behavior here
                 case TargetStates.Fleeing:
+                    movementControls.isFleeing = true;
+
+                    // Check for stun
+                    DetectStun();
+
+                    // Check if destination is reached
+                    if (movementControls.IsAtDestination())
+                        Reset();
                     break;
 
                 // Handle death condition here
@@ -79,6 +95,28 @@ public class Target : MonoBehaviour
         }
     }
 
+    // Method used for setting target flee timer publicly
+    public void SetFleeTimer()
+    {
+        fleeTimer = timeUntilFlee;
+    }
+
+    // Method for checking if target has been stunned
+    void DetectStun()
+    {
+        // Check for player input coords hitting target
+        Vector3 shotPos = inputManager.MouseWorldPosition;
+        RaycastHit2D hit = Physics2D.Raycast(shotPos, Vector2.zero);
+        if (hit && inputManager.MouseLeftDownThisFrame && Time.timeScale > 0) // Check time scale so bats cant be harmed while game is paused
+        {
+            // Check that hit has detected this particular object
+            if (hit.collider.gameObject == gameObject)
+            {
+                currentState = TargetStates.Death;
+            }
+        }
+    }
+
     // Method used for resetting the target
     void Reset()
     {
@@ -87,26 +125,34 @@ public class Target : MonoBehaviour
         transform.position = spawnPoint;
         movementControls.canMove = false;
 
+        // Choose new wander position to be used on respawn
+        movementControls.SetWanderPosition();
+
         GameManager gameManager = GameManager.Instance;
 
         // Update the target manager
         gameManager.TargetManager.numStuns++;
 
-        // Add points
-        gameManager.PointsManager.AddRoundPoints(pointValue);
+        // Add points if target didn't flee
+        if(currentState != TargetStates.Fleeing)
+            gameManager.PointsManager.AddRoundPoints(pointValue);
         
         // Add a successful hit
         gameManager.HitsManager.AddHit();
 
         if (GameManager.Instance.TargetManager.numStuns >= GameManager.Instance.TargetManager.currentRoundSize)
         {
-            // A little verbose, but can be improved later on
-            PointsManager pointsManager = GameManager.Instance.PointsManager;
-            pointsManager.AddBonusPoints(GameManager.Instance.HitsManager.Accuracy);
-            pointsManager.AddTotal();
+            // Only add points if target didn't flee
+            if (currentState != TargetStates.Fleeing)
+            {
+                // A little verbose, but can be improved later on
+                PointsManager pointsManager = GameManager.Instance.PointsManager;
+                pointsManager.AddBonusPoints(GameManager.Instance.HitsManager.Accuracy);
+                pointsManager.AddTotal();
+            }
 
             // Take into account the round cap
-            if (GameManager.Instance.TargetManager.currentRound == 4)
+            if (GameManager.Instance.TargetManager.currentRound == 10)
             {
                 return;
             }
@@ -114,6 +160,11 @@ public class Target : MonoBehaviour
             // Begin the next round and update params
             GameManager.Instance.TargetManager.UpdateRoundParameters();
             GameManager.Instance.TargetManager.StartNextRound();
+        }
+        else
+        {
+            // Try spawning another target
+            GameManager.Instance.TargetManager.SpawnMoreTargets();
         }
     }
 }

--- a/80s Game/Assets/Scripts/TargetManager.cs
+++ b/80s Game/Assets/Scripts/TargetManager.cs
@@ -74,16 +74,36 @@ public class TargetManager : MonoBehaviour
                 if (targetIndex >= 0)
                 {
                     SpawnTarget(targetIndex);
+
+                    // Check if screen is now full
+                    if (GetAllTargetsOnScreen().Length == maxTargetsOnScreen)
+                        return;
                 }
             }
         }
     }
 
     // Method for spawning more targets if needed
-    void SpawnMoreTargets()
+    public void SpawnMoreTargets()
     {
-        // TO-DO
-        // When we get to future rounds
+        // Check if stuns are needed
+        int neededStuns = currentRoundSize - numStuns;
+        if (neededStuns > 0)
+        {
+            if (GetAllTargetsOnScreen().Length < neededStuns)
+            {
+                // Check that screen isn't full
+                if (GetAllTargetsOnScreen().Length < maxTargetsOnScreen)
+                {
+                    // Spawn a target
+                    int targetIndex = GetNextAvailableTarget();
+                    if (targetIndex >= 0)
+                    {
+                        SpawnTarget(targetIndex);
+                    }
+                }
+            }
+        }
     }
 
     // Method for spawning a target
@@ -96,6 +116,7 @@ public class TargetManager : MonoBehaviour
         // Update on-screen status
         targets[targetIndex].isOnScreen = true;
         targets[targetIndex].currentState = TargetStates.Moving;
+        targets[targetIndex].SetFleeTimer();
     }
 
     // Method for getting all targets currently on screen


### PR DESCRIPTION
**Summary of What is Being added**
Added support for target manager to handle a larger amount of rounds and set current cap to ten. Also added flee behavior and updated both the state machine and kinematic steering component to support it.

**Please Describe How to test**
Just need to make sure the flee position is set for all bats in the editor. If that is set then you only need to test through playing the game and looking that everything transitions along with bats fleeing the scene.

**Can This be Tested with mouse input**
Yes

**What Sprint is this Due in?**
Sprint 3