### PR TITLE
Made JoyCon tweaks and some UI additions

### DIFF
--- a/80s Game/Assets/Scenes/SampleScene.unity
+++ b/80s Game/Assets/Scenes/SampleScene.unity
@@ -150,14 +150,14 @@ RectTransform:
   m_GameObject: {fileID: 34614437}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.3889, y: 1.3889, z: 1.3889}
+  m_LocalScale: {x: 2.3787675, y: 2.3787675, z: 2.3787675}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1681867055}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -137}
+  m_AnchoredPosition: {x: 0, y: -176}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &34614439
@@ -180,7 +180,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: bf1cc61d2283d32488203be423a26595, type: 3}
+  m_Sprite: {fileID: 21300000, guid: b276e073f04036041ab1761e836da248, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -838,7 +838,7 @@ GameObject:
   - component: {fileID: 164703859}
   - component: {fileID: 164703858}
   m_Layer: 5
-  m_Name: Initial 1 Button Down
+  m_Name: Initial 1 Button Up
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -909,7 +909,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1619173213}
         m_TargetAssemblyTypeName: HighScoreInitials, Assembly-CSharp
-        m_MethodName: DecreaseInitial
+        m_MethodName: IncreaseInitial
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1183,7 +1183,7 @@ GameObject:
   - component: {fileID: 198742987}
   - component: {fileID: 198742986}
   m_Layer: 5
-  m_Name: Initial 2 Button Up
+  m_Name: Initial 2 Button Down
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1254,7 +1254,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1619173213}
         m_TargetAssemblyTypeName: HighScoreInitials, Assembly-CSharp
-        m_MethodName: IncreaseInitial
+        m_MethodName: DecreaseInitial
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1434,7 +1434,7 @@ GameObject:
   - component: {fileID: 286634399}
   - component: {fileID: 286634398}
   m_Layer: 5
-  m_Name: Initial 1 Button Up
+  m_Name: Initial 1 Button Down
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1505,7 +1505,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1619173213}
         m_TargetAssemblyTypeName: HighScoreInitials, Assembly-CSharp
-        m_MethodName: IncreaseInitial
+        m_MethodName: DecreaseInitial
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2075,7 +2075,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &367589953
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3365,6 +3365,142 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &736886328
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 736886329}
+  - component: {fileID: 736886331}
+  - component: {fileID: 736886330}
+  m_Layer: 5
+  m_Name: Round Indicator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &736886329
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 736886328}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1759806106}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 783, y: 443.04}
+  m_SizeDelta: {x: 358.0116, y: 193.9195}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &736886330
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 736886328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Round
+
+'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
+  m_sharedMaterial: {fileID: -507269567956872517, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 50.05
+  m_fontSizeBase: 50.05
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &736886331
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 736886328}
+  m_CullTransparentMesh: 1
 --- !u!1 &747152778 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 232502045716647642, guid: 35d5b47dfd1f8c94a8f3a81373daaf66, type: 3}
@@ -4100,6 +4236,7 @@ MonoBehaviour:
   scoreTextObject: {fileID: 1554343130}
   highScoreTextObject: {fileID: 153801723}
   finalScoreTextObject: {fileID: 1117114116}
+  roundIndicatorTextObject: {fileID: 736886330}
 --- !u!1 &1095139969
 GameObject:
   m_ObjectHideFlags: 0
@@ -4184,6 +4321,7 @@ MonoBehaviour:
   jc_ind: 0
   orientation: {x: 0, y: 0, z: 0, w: 0}
   joyconCursorPos: {x: 0, y: 0, z: 0}
+  pauseScript: {fileID: 1011990663}
 --- !u!114 &1095139974
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5931,7 +6069,7 @@ GameObject:
   - component: {fileID: 1565045410}
   - component: {fileID: 1565045409}
   m_Layer: 5
-  m_Name: Initial 2 Button Down
+  m_Name: Initial 2 Button Up
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -6002,7 +6140,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1619173213}
         m_TargetAssemblyTypeName: HighScoreInitials, Assembly-CSharp
-        m_MethodName: DecreaseInitial
+        m_MethodName: IncreaseInitial
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -6491,7 +6629,7 @@ GameObject:
   - component: {fileID: 1715946390}
   - component: {fileID: 1715946389}
   m_Layer: 5
-  m_Name: Initial 3 Button Up
+  m_Name: Initial 3 Button Down
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -6562,7 +6700,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1619173213}
         m_TargetAssemblyTypeName: HighScoreInitials, Assembly-CSharp
-        m_MethodName: IncreaseInitial
+        m_MethodName: DecreaseInitial
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -6742,7 +6880,7 @@ GameObject:
   - component: {fileID: 1722158114}
   - component: {fileID: 1722158113}
   m_Layer: 5
-  m_Name: Initial 3 Button Down
+  m_Name: Initial 3 Button Up
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -6813,7 +6951,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1619173213}
         m_TargetAssemblyTypeName: HighScoreInitials, Assembly-CSharp
-        m_MethodName: DecreaseInitial
+        m_MethodName: IncreaseInitial
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -7353,6 +7491,7 @@ RectTransform:
   - {fileID: 367589953}
   - {fileID: 153801722}
   - {fileID: 1554343129}
+  - {fileID: 736886329}
   m_Father: {fileID: 1011990662}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}

--- a/80s Game/Assets/Scripts/HitsManager.cs
+++ b/80s Game/Assets/Scripts/HitsManager.cs
@@ -30,6 +30,11 @@ public class HitsManager : MonoBehaviour
         // When the player clicks and the game isn't paused, add a shot
         if (GameManager.Instance.InputManager.MouseLeftDownThisFrame && Time.timeScale > 0)
         {
+            if (GameManager.Instance.InputManager.joycons.Count > 0)
+            {
+                Joycon j = GameManager.Instance.InputManager.joycons[GameManager.Instance.InputManager.jc_ind];
+                j.SetRumble(160, 320, 0.6f, 200);
+            }
             AddShot();
         }
     }

--- a/80s Game/Assets/Scripts/InputManager.cs
+++ b/80s Game/Assets/Scripts/InputManager.cs
@@ -31,11 +31,14 @@ public class InputManager : MonoBehaviour
     public Quaternion orientation;
     public Vector3 joyconCursorPos;
 
+    public PauseScreenBehavior pauseScript;
+
     void Start()
     {
         joycons = JoyconManager.Instance.j;
         gyro = new Vector3(0, 0, 0);
-        joyconCursorPos = new Vector3(0, 0, 0);
+        RecenterCursor();
+        ResetRumble();
     }
 
     // Update is called once per frame
@@ -72,6 +75,29 @@ public class InputManager : MonoBehaviour
             // Get right trigger input
             MouseLeftDownThisFrame = j.GetButtonDown(Joycon.Button.SHOULDER_2);
 
+            if (j.GetButtonDown(Joycon.Button.DPAD_DOWN))
+            {
+                RecenterCursor();
+            }
+
+            if (j.GetButtonDown(Joycon.Button.PLUS) && !pauseScript.isPaused)
+            {
+                pauseScript.PauseGame();
+            }
+        }
+    }
+
+    public void RecenterCursor()
+    {
+        joyconCursorPos = new Vector3(Screen.width/2, Screen.height / 2, 0);
+    }
+
+    public void ResetRumble()
+    {
+        if (joycons.Count > 0)
+        {
+            Joycon j = joycons[jc_ind];
+            j.SetRumble(0, 0, 0);
         }
     }
 }

--- a/80s Game/Assets/Scripts/UI Scripts/HighScoreInitials.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/HighScoreInitials.cs
@@ -43,14 +43,29 @@ public class HighScoreInitials : MonoBehaviour
         {
             //Used for first initial
             case 1:
+                if (initialOne == 90)
+                {
+                    initialOne = 65;
+                    break;
+                }
                 initialOne = Mathf.Clamp(++initialOne, 65, 90);
                 break;
             //Used for second initial
             case 2:
+                if (initialTwo == 90)
+                {
+                    initialTwo = 65;
+                    break;
+                }
                 initialTwo = Mathf.Clamp(++initialTwo, 65, 90);
                 break;
             //Used for third initial
             case 3:
+                if (initialThree == 90)
+                {
+                    initialThree = 65;
+                    break;
+                }
                 initialThree = Mathf.Clamp(++initialThree, 65, 90);
                 break;
             default:
@@ -67,14 +82,29 @@ public class HighScoreInitials : MonoBehaviour
         {
             //Used for first initial
             case 1:
+                if (initialOne == 65)
+                {
+                    initialOne = 90;
+                    break;
+                }
                 initialOne = Mathf.Clamp(--initialOne, 65, 90);
                 break;
             //Used for second initial
             case 2:
+                if (initialTwo == 65)
+                {
+                    initialTwo = 90;
+                    break;
+                }
                 initialTwo = Mathf.Clamp(--initialTwo, 65, 90);
                 break;
             //Used for third initial
             case 3:
+                if (initialThree == 65)
+                {
+                    initialThree = 90;
+                    break;
+                }
                 initialThree = Mathf.Clamp(--initialThree, 65, 90);
                 break;
             default:

--- a/80s Game/Assets/Scripts/UI Scripts/OnboardingUI.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/OnboardingUI.cs
@@ -11,8 +11,8 @@ public class OnboardingUI : MonoBehaviour
     public TMP_Text onboardingText;
     
     //Fields for onboarding text to be displayed to the player
-    private string mouseInputText = "The Bat Bots have escaped containment! \n\nAim your stun gun with the mouse and fire with left-click to stun the bat bots.";
-    private string joyconInputText = "The Bat Bots have escaped containment! \n\nAim your stun gun by tilting the JoyCon. \n\nFire with the trigger (ZR/ZL) to stun the bat bots.";
+    private string mouseInputText = "The bat bots have escaped containment! \n\nAim your stun gun with the mouse and fire with left-click to stun the bat bots.";
+    private string joyconInputText = "The bat bots have escaped containment! \n\nAim your stun gun by tilting the JoyCon. \n\nFire with the trigger (ZR/ZL) to stun the bat bots.";
 
 
     // Start is called before the first frame update

--- a/80s Game/Assets/Scripts/UI Scripts/PauseScreenBehavior.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/PauseScreenBehavior.cs
@@ -15,13 +15,13 @@ public class PauseScreenBehavior : MonoBehaviour
     void Update()
     {
         //Pause game if escape key is pressed
-        if (Input.GetKeyDown("escape") && !onboardingPanel.activeInHierarchy && !GameManager.Instance.TargetManager.gameOver)
+        if (Input.GetKeyDown("escape") && (!onboardingPanel.activeInHierarchy || pauseScreen.activeInHierarchy) && !GameManager.Instance.TargetManager.gameOver)
         {
             PauseGame();
         }
 
         //If the onboarding panel is active when escape is pressed, close it and start the game
-        else if (Input.GetKeyDown("escape") && onboardingPanel.activeInHierarchy)
+        else if (Input.GetKeyDown("escape") && onboardingPanel.activeInHierarchy && !pauseScreen.activeInHierarchy)
         {
             onboardingPanel.SetActive(false);
             gameUIElements.SetActive(true);
@@ -32,33 +32,34 @@ public class PauseScreenBehavior : MonoBehaviour
 
     public void PauseGame()
     {
+        //GameManager.Instance.InputManager.ResetRumble();
         isPaused = !isPaused;
         if (isPaused == true)
         {
+            //Sets time scale to 0 so game pauses
+            Time.timeScale = 0f;
+
             //Enable pause screen and onboarding info (except the button to close onboarding)
             pauseScreen.SetActive(true);
             onboardingPanel.SetActive(true);
             onboardingCloseButton.SetActive(false);
             gameUIElements.SetActive(false);
-
-            //Sets time scale to 0 so game pauses
-            Time.timeScale = 0f;
         }
 
         else
         {
+            //Sets time scale to 1 so game unpauses
+            Time.timeScale = 1f;
+
             pauseScreen.SetActive(false);
             onboardingPanel.SetActive(false);
             gameUIElements.SetActive(true);
-
-            //Sets time scale to 1 so game unpauses
-            Time.timeScale = 1f;
         }
     }
 
     public void QuitGame()
     {
-        SceneManager.LoadScene(0);
         Time.timeScale = 1f;
+        SceneManager.LoadScene(0);
     }
 }

--- a/80s Game/Assets/Scripts/UI Scripts/ScoreBehavior.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/ScoreBehavior.cs
@@ -9,11 +9,13 @@ public class ScoreBehavior : MonoBehaviour
     public TMP_Text scoreTextObject;
     public TMP_Text highScoreTextObject;
     public TMP_Text finalScoreTextObject;
+    public TMP_Text roundIndicatorTextObject;
 
     //Strings for text minus the score values
     private string scoreText = "Score:\n";
     private string highScoreText = "High Score:\n";
     private string finalScoreText = "Final Score: ";
+    private string roundText = "Round\n";
 
     //Placeholder high score (Replace with File IO stuff)
     private int highScore = 20000;
@@ -29,10 +31,15 @@ public class ScoreBehavior : MonoBehaviour
     {
         //Get the score from the PointsManager
         int score = GameManager.Instance.PointsManager.Points;
+        int currentRoundNum = GameManager.Instance.TargetManager.currentRound;
+        int maxNumOfRounds = GameManager.Instance.TargetManager.numRounds;
 
         //Update Score and Final Score text boxes
         scoreTextObject.SetText(scoreText + score);
         finalScoreTextObject.SetText(finalScoreText + score);
+
+        //Update Round Indicator
+        roundIndicatorTextObject.SetText(roundText + currentRoundNum + "/" + maxNumOfRounds);
 
         //If you beat the high score, list the current score under high score as well
         if (score > highScore)


### PR DESCRIPTION
Summary of What is Being added
-Button Input added to recenter the cursor (Bottom Face Button on JoyCon)
-Rumble Support added for firing with JoyCon
-Pause Button removed and replaced with Escape for Mouse & Keyboard and Plus button on JoyCon
-Initial buttons on High Score screen swapped and now loop through initials
-Sprite on onboarding panel replaced with more up to date sprite
-Cursor now starts centered when a JoyCon is connected
-Round Indicator added

Please Describe How to test
-Play through the game as normal, round indicator should be visible, and accurate
-When getting to the high score leaderboard, the initial buttons should loop properly (i.e. clicking up when on 'A' should set it to 'Z')
-Click the bottom face button on a JoyCon controller to recenter the cursor
-Click the plus button on the JoyCon to pause the game (doesn't unpause currently)
-Make sure the controller rumbles when firing in the game

Can This be Tested with mouse input
-The UI changes yes.
-Anything JoyCon related? No

What Sprint is this Due in?
Sprint 4