### PR TITLE
Changes to SoundManager, Added Shoot Sound

### DIFF
--- a/80s Game/Assets/Prefabs/TestTarget.prefab
+++ b/80s Game/Assets/Prefabs/TestTarget.prefab
@@ -58,6 +58,7 @@ MonoBehaviour:
   timeUntilFlee: 5
   fleeLocation: {x: 0, y: 0}
   hitSound: {fileID: 8300000, guid: c928b956a133aa544bfa866c9b7c2b47, type: 3}
+  missSound: {fileID: 8300000, guid: 58d7a57419c677f4faa04f97ea74938c, type: 3}
 --- !u!50 &4043134783524271435
 Rigidbody2D:
   serializedVersion: 4

--- a/80s Game/Assets/Prefabs/UnstableTarget.prefab
+++ b/80s Game/Assets/Prefabs/UnstableTarget.prefab
@@ -245,5 +245,6 @@ MonoBehaviour:
   timeUntilFlee: 5
   fleeLocation: {x: 0, y: 10}
   hitSound: {fileID: 8300000, guid: c928b956a133aa544bfa866c9b7c2b47, type: 3}
+  missSound: {fileID: 8300000, guid: 58d7a57419c677f4faa04f97ea74938c, type: 3}
   chainRadius: 2
   chainLength: 3

--- a/80s Game/Assets/Scenes/SampleScene.unity
+++ b/80s Game/Assets/Scenes/SampleScene.unity
@@ -4408,6 +4408,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ecb3240ed8294404ba046c9ad4331252, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  shootSound: {fileID: 8300000, guid: 58d7a57419c677f4faa04f97ea74938c, type: 3}
   gyro: {x: 0, y: 0, z: 0}
   jc_ind: 0
   orientation: {x: 0, y: 0, z: 0, w: 0}
@@ -4471,6 +4472,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1230458697}
+  - {fileID: 1136557142}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1107071141
@@ -4485,7 +4487,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a2dadec502d609343a86c314a816809a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  audio: {fileID: 1230458698}
+  interruptSource: {fileID: 1230458698}
+  continuousSource: {fileID: 1136557141}
 --- !u!1 &1107327210
 GameObject:
   m_ObjectHideFlags: 0
@@ -4888,6 +4891,134 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1117114114}
   m_CullTransparentMesh: 1
+--- !u!1 &1136557140
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1136557142}
+  - component: {fileID: 1136557141}
+  m_Layer: 0
+  m_Name: continuousSource
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!82 &1136557141
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1136557140}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!4 &1136557142
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1136557140}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -14.22, y: -8.690001, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1107071140}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1140345283
 GameObject:
   m_ObjectHideFlags: 0
@@ -5167,7 +5298,7 @@ GameObject:
   - component: {fileID: 1230458697}
   - component: {fileID: 1230458698}
   m_Layer: 0
-  m_Name: sound source
+  m_Name: interruptSource
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/80s Game/Assets/Scripts/InputManager.cs
+++ b/80s Game/Assets/Scripts/InputManager.cs
@@ -23,6 +23,7 @@ public class InputManager : MonoBehaviour
         get;
         private set;
     }
+    public AudioClip shootSound;
 
     // Joycon fields
     public List<Joycon> joycons;
@@ -84,6 +85,10 @@ public class InputManager : MonoBehaviour
             {
                 pauseScript.PauseGame();
             }
+        }
+        if (MouseLeftDownThisFrame && !pauseScript.isPaused)
+        {
+            SoundManager.Instance.PlaySoundContinuous(shootSound);
         }
     }
 

--- a/80s Game/Assets/Scripts/SoundManager.cs
+++ b/80s Game/Assets/Scripts/SoundManager.cs
@@ -7,7 +7,8 @@ public class SoundManager : MonoBehaviour
     //singleton implementation adapted from an online tutorial: https://www.youtube.com/watch?v=tEsuLTpz_DU
     public static SoundManager Instance;
 
-    public AudioSource audio; //uses a single audio source
+    public AudioSource interruptSource; //audio source for sounds which cancel each other out
+    public AudioSource continuousSource; //audio source for sounds which cannot be interrupted
 
     void Awake()
     {
@@ -19,12 +20,17 @@ public class SoundManager : MonoBehaviour
         else Destroy(gameObject);
     }
 
-    public void PlaySound(AudioClip clip)
+    public void PlaySoundInterrupt(AudioClip clip)
     {
-        if (audio.isPlaying) 
+        if (interruptSource.isPlaying) 
         {
-            audio.Stop();
+            interruptSource.Stop();
         }
-        audio.PlayOneShot(clip);
+        interruptSource.PlayOneShot(clip);
+    }
+
+    public void PlaySoundContinuous(AudioClip clip)
+    { 
+        continuousSource.PlayOneShot(clip);
     }
 }

--- a/80s Game/Assets/Scripts/Target.cs
+++ b/80s Game/Assets/Scripts/Target.cs
@@ -31,6 +31,7 @@ public class Target : MonoBehaviour
     protected AnimationHandler animControls;
     CircleCollider2D collider;
     public AudioClip hitSound;
+    //public AudioClip missSound;
 
     // Default fields used for resets
     Vector3 spawnPoint;
@@ -133,13 +134,16 @@ public class Target : MonoBehaviour
 
             // Check if something was hit
             if (!hit)
+            {
+                //SoundManager.Instance.PlaySoundContinuous(missSound);
                 return;
+            }
 
             // Check that hit has detected this particular object
             if (hit.collider.gameObject == gameObject)
             {
                 animControls.PlayStunAnimation();
-                SoundManager.Instance.PlaySound(hitSound);
+                SoundManager.Instance.PlaySoundInterrupt(hitSound);
             }
         }
     }

--- a/80s Game/Assets/Scripts/UnstableTarget.cs
+++ b/80s Game/Assets/Scripts/UnstableTarget.cs
@@ -19,14 +19,17 @@ public class UnstableTarget : Target
             RaycastHit2D hit = Physics2D.Raycast(shotPos, Vector2.zero);
 
             // Check if something was hit
-            if (!hit)
-                return;
+            if (!hit) 
+            { 
+                //SoundManager.Instance.PlaySound(missSound); 
+                return; 
+            }
 
             // Check that hit has detected this particular object
             if (hit.collider.gameObject == gameObject)
             {
                 animControls.PlayStunAnimation();
-                SoundManager.Instance.PlaySound(hitSound);
+                SoundManager.Instance.PlaySoundInterrupt(hitSound);
 
                 // Get the chain of targets
                 Target[] targetChain = GetTargetChain();


### PR DESCRIPTION
Slightly altered functionality of SoundManager: now has two separate audio sources, one for clips which can overlap and should play to the end no matter what, and one for clips which should not overlap and are mutually exclusive. These are utilized via two separate static methods, known as PlaySoundContinuous and PlaySoundInterrupt, respectively.

Shock/stun/hit sound for both Normal and Unstable Bats now uses the interruptSource, meaning only one instance of the hit sound may be played at once.

Also added a sound for shooting, which is played through the InputManager on click (when the game is not paused).

Can be tested with mouse. Test by playing the game, and noting how/when/which sounds overlap or cut each other off. Also try this with the Title screen, because I haven't done anything with it [directly] just yet.

Due in Sprint 4.