### PR TITLE
Randomized flee location and increased flee timer

### DIFF
--- a/80s Game/Assets/Scripts/Target.cs
+++ b/80s Game/Assets/Scripts/Target.cs
@@ -19,7 +19,7 @@ public class Target : MonoBehaviour
     public float deathHeight = -6.5f;
 
     // Fleeing fields
-    public float timeUntilFlee = 5.0f;
+    public float timeUntilFlee = 8.0f;
     float fleeTimer = 0.0f;
     public Vector2 fleeLocation;
 
@@ -71,6 +71,13 @@ public class Target : MonoBehaviour
                     if(fleeTimer <= 0.0f) // When timer is up, set target to flee
                     {
                         currentState = TargetStates.Fleeing;
+
+                        // Get max height and width values from screen
+                        float maxHeight = Camera.main.GetComponent<Camera>().orthographicSize;
+                        float maxWidth = maxHeight * (Screen.width / Screen.height);
+
+                        // Find random x position
+                        fleeLocation.x = UnityEngine.Random.Range((-maxWidth * 2) + GetComponent<SpriteRenderer>().size.x, (maxWidth * 2) - GetComponent<SpriteRenderer>().size.x);
                         movementControls.SetTargetPosition(fleeLocation);
                     }
 


### PR DESCRIPTION
**Summary of What is Being added**
- Randomized flee locations to still maintain general y value but have an unpredictable x value
- Tweaked the flee timer to be longer and changed it from 5s to 8s

**Please Describe How to test**
Play as normal and let the bats flee. See how long it takes for them to flee and the general location they flee to.

**Can This be Tested with mouse input**
Yes

**What Sprint is this Due in?**
Sprint 5