### PR TITLE
Added Xbox Controller support

### DIFF
--- a/80s Game/Assets/PlayerInput/InputActions.inputactions
+++ b/80s Game/Assets/PlayerInput/InputActions.inputactions
@@ -49,7 +49,7 @@
                     "path": "<Gamepad>/leftStick",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4",
+                    "groups": "PS4;Xbox",
                     "action": "Move",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -66,12 +66,67 @@
                     "isPartOfComposite": false
                 },
                 {
+                    "name": "2D Vector",
+                    "id": "299fc252-322f-4ec5-92c7-05ee7394d3e1",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "25236259-3c7c-4bbf-829b-0bb8e990ac30",
+                    "path": "<Gamepad>/dpad/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "PS4;Xbox",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "6a0eb3bc-c65b-4d99-84e4-976a28d1ddff",
+                    "path": "<Gamepad>/dpad/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "PS4;Xbox",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "96d4a3f1-7a2b-427b-a6e0-8513968ec317",
+                    "path": "<Gamepad>/dpad/left",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "PS4;Xbox",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "a9265512-56d5-4e19-a5cf-d0e4fbfc97f9",
+                    "path": "<Gamepad>/dpad/right",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "PS4;Xbox",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
                     "name": "",
                     "id": "4612a35c-d637-46fd-bc87-62b56bf4c896",
                     "path": "<Gamepad>/rightTrigger",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4",
+                    "groups": "PS4;Xbox",
                     "action": "Fire",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -93,7 +148,7 @@
                     "path": "<Gamepad>/start",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4",
+                    "groups": "PS4;Xbox",
                     "action": "Pause",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -146,6 +201,17 @@
             "devices": [
                 {
                     "devicePath": "<DualShockGamepad>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        },
+        {
+            "name": "Xbox",
+            "bindingGroup": "Xbox",
+            "devices": [
+                {
+                    "devicePath": "<XInputController>",
                     "isOptional": false,
                     "isOR": false
                 }

--- a/80s Game/Assets/Scenes/TitleScreen.unity
+++ b/80s Game/Assets/Scenes/TitleScreen.unity
@@ -895,6 +895,7 @@ MonoBehaviour:
   onboardingPanel: {fileID: 0}
   onboardingCloseButton: {fileID: 0}
   buttonClickSound: {fileID: 0}
+  crosshairs: []
 --- !u!114 &319221314
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -981,7 +982,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 379cbbec416febe4ca84352fed88c256, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerPrefab: {fileID: 0}
+  playerPrefab: {fileID: 3927707039747870840, guid: bc3f50abd22028041ab5a1ce97145ecf, type: 3}
 --- !u!4 &340111862
 Transform:
   m_ObjectHideFlags: 0
@@ -1383,7 +1384,7 @@ GameObject:
   m_Component:
   - component: {fileID: 450670734}
   - component: {fileID: 450670733}
-  - component: {fileID: 450670735}
+  - component: {fileID: 450670736}
   m_Layer: 0
   m_Name: EventSystem
   m_TagString: Untagged
@@ -1421,7 +1422,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &450670735
+--- !u!114 &450670736
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1430,22 +1431,27 @@ MonoBehaviour:
   m_GameObject: {fileID: 450670731}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e8614de803fad3419913a730204b7c7, type: 3}
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_SendPointerHoverToParent: 1
-  DesiredResX: 1920
-  DesiredResY: 1080
-  FisheyeX: 0.05
-  FisheyeY: 0.05
-  StretchToDisplay: 1
-  DisplayAspect: 1.33
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_AllowActivationOnMobileDevice: 0
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
 --- !u!1 &474591588
 GameObject:
   m_ObjectHideFlags: 0

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
@@ -15,12 +15,12 @@ public class PlayerInputWrapper : MonoBehaviour
     {
         player = GetComponent<PlayerController>();
         playerInput = GetComponent<PlayerInput>();
-        if (playerInput.currentControlScheme == "PS4")
-        {
-            sensitivity = controllerSensitivity;
-        } else
+        if (playerInput.currentControlScheme == "KnM")
         {
             sensitivity = mouseSensitivity;
+        } else
+        {
+            sensitivity = controllerSensitivity;
         }
     }
 


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Added support for Xbox controllers as well as added support for movement to be used with the D-pad as well as the analog stick.

## Please describe how to test
Connect an Xbox controller and try playing the game.
Try navigating through menus using d-pad


## Relevant Screenshots
Navigation through Dpad added to InputActions
![image](https://github.com/mythguy1226/80sgame/assets/9394777/5074926a-fe49-47fa-a441-f97de6f7a7fd)

## Issue worked on
No tagged issue

## What Sprint is this due in?
Sprint 1