### PR TITLE
Feature/pause screen

### DIFF
--- a/80s Game/Assets/PlayerInput/InputActions.inputactions
+++ b/80s Game/Assets/PlayerInput/InputActions.inputactions
@@ -49,7 +49,7 @@
                     "path": "<Gamepad>/leftStick",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4;Xbox",
+                    "groups": "PS4",
                     "action": "Move",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -82,7 +82,7 @@
                     "path": "<Gamepad>/dpad/up",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4;Xbox",
+                    "groups": "PS4",
                     "action": "Move",
                     "isComposite": false,
                     "isPartOfComposite": true
@@ -93,7 +93,7 @@
                     "path": "<Gamepad>/dpad/down",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4;Xbox",
+                    "groups": "PS4",
                     "action": "Move",
                     "isComposite": false,
                     "isPartOfComposite": true
@@ -104,7 +104,7 @@
                     "path": "<Gamepad>/dpad/left",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4;Xbox",
+                    "groups": "PS4",
                     "action": "Move",
                     "isComposite": false,
                     "isPartOfComposite": true
@@ -115,7 +115,7 @@
                     "path": "<Gamepad>/dpad/right",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4;Xbox",
+                    "groups": "PS4",
                     "action": "Move",
                     "isComposite": false,
                     "isPartOfComposite": true
@@ -126,7 +126,7 @@
                     "path": "<Gamepad>/rightTrigger",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4;Xbox",
+                    "groups": "PS4",
                     "action": "Fire",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -148,7 +148,7 @@
                     "path": "<Gamepad>/start",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4;Xbox",
+                    "groups": "PS4",
                     "action": "Pause",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -157,6 +157,17 @@
                     "name": "",
                     "id": "b86f2645-2b16-4412-827d-28b587b967f2",
                     "path": "<Keyboard>/escape",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KnM",
+                    "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c1ba9ef3-de50-41bc-bc23-129d69e831ed",
+                    "path": "<Keyboard>/space",
                     "interactions": "",
                     "processors": "",
                     "groups": "KnM",
@@ -200,18 +211,7 @@
             "bindingGroup": "PS4",
             "devices": [
                 {
-                    "devicePath": "<DualShockGamepad>",
-                    "isOptional": false,
-                    "isOR": false
-                }
-            ]
-        },
-        {
-            "name": "Xbox",
-            "bindingGroup": "Xbox",
-            "devices": [
-                {
-                    "devicePath": "<XInputController>",
+                    "devicePath": "<Gamepad>",
                     "isOptional": false,
                     "isOR": false
                 }

--- a/80s Game/Assets/Scenes/Eduardo-NewInputSystem.unity
+++ b/80s Game/Assets/Scenes/Eduardo-NewInputSystem.unity
@@ -4851,6 +4851,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerPrefab: {fileID: 3927707039747870840, guid: bc3f50abd22028041ab5a1ce97145ecf, type: 3}
+  debug: 1
 --- !u!4 &1095139975
 Transform:
   m_ObjectHideFlags: 0

--- a/80s Game/Assets/Scenes/JoinScene.unity
+++ b/80s Game/Assets/Scenes/JoinScene.unity
@@ -572,6 +572,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerPrefab: {fileID: 3927707039747870840, guid: bc3f50abd22028041ab5a1ce97145ecf, type: 3}
+  debug: 0
 --- !u!4 &1384543482
 Transform:
   m_ObjectHideFlags: 0
@@ -884,7 +885,7 @@ MonoBehaviour:
   m_NotificationBehavior: 0
   m_MaxPlayerCount: 4
   m_AllowJoining: 1
-  m_JoinBehavior: 0
+  m_JoinBehavior: 1
   m_PlayerJoinedEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -892,17 +893,25 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_JoinAction:
-    m_UseReference: 0
+    m_UseReference: 1
     m_Action:
-      m_Name: 
+      m_Name: Join
       m_Type: 0
       m_ExpectedControlType: 
       m_Id: b500ea57-e08c-4631-a3fd-c99f77c1ec42
       m_Processors: 
       m_Interactions: 
-      m_SingletonActionBindings: []
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: 85658bad-5e6b-4379-889e-968429841885
+        m_Path: 
+        m_Interactions: 
+        m_Processors: 
+        m_Groups: 
+        m_Action: Join
+        m_Flags: 0
       m_Flags: 0
-    m_Reference: {fileID: 0}
+    m_Reference: {fileID: -396693030614384387, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
   m_PlayerPrefab: {fileID: 391535260845415020, guid: bc3f50abd22028041ab5a1ce97145ecf, type: 3}
   m_SplitScreen: 0
   m_MaintainAspectRatioInSplitScreen: 0

--- a/80s Game/Assets/Scripts/GameManager.cs
+++ b/80s Game/Assets/Scripts/GameManager.cs
@@ -15,6 +15,9 @@ public class GameManager : MonoBehaviour
     public HitsManager HitsManager { get; private set; }
 
     public UIManager UIManager { get; private set; }
+    
+    [Tooltip("Debug to spawn a Player Controller for testing without having to go through the join screen")]
+    public bool debug;
 
     private void Awake()
     {
@@ -36,7 +39,7 @@ public class GameManager : MonoBehaviour
             HitsManager = GetComponent<HitsManager>();
             UIManager = GetComponent<UIManager>();
 
-            if (PlayerData.activePlayers.Count == 0) {
+            if (PlayerData.activePlayers.Count == 0 && debug) {
                 PlayerConfig defaultConfig = new PlayerConfig(0, PlayerData.defaultColors[0], Vector2.one);
                 PlayerData.activePlayers.Add(defaultConfig);
                 PlayerController pc = Instantiate(playerPrefab, transform.position, Quaternion.identity);

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
@@ -60,4 +60,9 @@ public class PlayerController : MonoBehaviour
     {
         activeCrosshair.Center();
     }
+
+    public void EmitPause()
+    {
+        UIManager.PlayerPause();
+    }
 }

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
@@ -70,7 +70,7 @@ public class PlayerInputWrapper : MonoBehaviour
 
     private void OnPause(InputValue value)
     {
-
+        player.EmitPause();
     }
 
     private void OnPause()

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
@@ -8,11 +8,6 @@ public class PlayerJoinManager : MonoBehaviour
 
     private void OnPlayerJoined(PlayerInput playerInput)
     {
-        if (playerInput.playerIndex == 0)
-        {
-            // Skip the first player
-            return;
-        }
         PlayerConfig config = new PlayerConfig(playerInput.playerIndex, PlayerData.defaultColors[playerInput.playerIndex], Vector2.one);
         PlayerController pc = playerInput.gameObject.GetComponent<PlayerController>();
         PlayerData.activePlayers.Add(config);

--- a/80s Game/Assets/Scripts/UI Scripts/PauseScreenBehavior.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/PauseScreenBehavior.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
-using UnityEngine.UI;
 
 public class PauseScreenBehavior : MonoBehaviour
 {
@@ -16,6 +15,16 @@ public class PauseScreenBehavior : MonoBehaviour
     public AudioClip buttonClickSound;
 
     public Crosshair[] crosshairs;
+
+    private void Awake()
+    {
+        UIManager.pauseEvent += PauseGame;
+    }
+
+    private void OnDisable()
+    {
+        UIManager.pauseEvent -= PauseGame;
+    }
 
     void Start()
     {

--- a/80s Game/Assets/Scripts/UI Scripts/UIManager.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/UIManager.cs
@@ -1,7 +1,10 @@
+using System;
 using UnityEngine;
 
 public class UIManager : MonoBehaviour
 {
+
+    public static Action pauseEvent;
     public enum UIType
     {
         None,
@@ -41,5 +44,10 @@ public class UIManager : MonoBehaviour
             default:
                 return;
         }
+    }
+
+    public static void PlayerPause()
+    {
+        pauseEvent?.Invoke();
     }
 }


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Pause screen can now be pulled up by controllers.
Mouse and Keyboard also supports using Space (in addition to Escape) to pull up the pause screen. This way in-editor pressing of escape doesn't impede pulling up the pause screen.
Changed the behavior of the Join Screen to join OnFire. Should reduce multi-spawn problems.

## Please describe how to test
Play the game with a controller connected. Press Start. Should pull up the options screen.
Play the game with Mouse and Keyboard. Hit Space. Should pull up the options screen.

## Relevant Screenshots
Nothing to show that properly describes the behavior

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-46

## What Sprint is this due in?
Sprint 1