### PR TITLE
Game mode selector now in GameManager inspector

### DIFF
--- a/80s Game/Assets/Scenes/CompetitiveMode.unity
+++ b/80s Game/Assets/Scenes/CompetitiveMode.unity
@@ -8557,6 +8557,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   playerPrefab: {fileID: 3927707039747870840, guid: bc3f50abd22028041ab5a1ce97145ecf, type: 3}
   roundEndTheme: {fileID: 8300000, guid: d513d718f482f2d42a5402d152e5f893, type: 3}
+  gameModeType: 1
   debug: 1
 --- !u!4 &1095139975
 Transform:

--- a/80s Game/Assets/Scripts/GameManager.cs
+++ b/80s Game/Assets/Scripts/GameManager.cs
@@ -12,6 +12,9 @@ public class GameManager : MonoBehaviour
     public AudioClip roundEndTheme;     //putting this here so it can be called by GameMode subclasses
     //public AudioClip failstateTheme;  //for future implementation of losable game mode(s), e.g. defense mode
 
+    // Change in Inspector
+    public EGameMode gameModeType = EGameMode.Classic;
+
     public AbsGameMode ActiveGameMode { get; private set; }
     // Public properties
     public InputManager InputManager { get; private set;  }
@@ -26,7 +29,6 @@ public class GameManager : MonoBehaviour
 
     private void Awake()
     {
-
         // Check if the static reference matches the script instance
         if(Instance != null && Instance != this)
         {
@@ -64,21 +66,19 @@ public class GameManager : MonoBehaviour
 
     private void Start() 
     {
-        Scene currentScene = SceneManager.GetActiveScene();
-        string sceneName = currentScene.name;
+        InitGameMode(gameModeType);
+    }
 
-        switch (sceneName)
+    public void InitGameMode(EGameMode gameModeType)
+    {
+        switch(gameModeType)
         {
-            case "SampleScene":
+            case EGameMode.Classic:
                 ActiveGameMode = new ClassicMode();
                 break;
-            case "CompetitiveMode":
+            case EGameMode.Competitive:
                 ActiveGameMode = new CompetitiveMode();
                 break;
-            /*
-             * case "...":
-             *  ActiveGameMode = new CompetativeMode(numRoundsCompetative);
-             */
         }
     }
 }

--- a/80s Game/Assets/Scripts/GameModes/GameMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/GameMode.cs
@@ -2,15 +2,15 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+public enum EGameMode
+{
+    Classic,
+    Competitive,
+    Defense
+}
+
 public abstract class AbsGameMode
 {
-    public enum EGameMode
-    {
-        Classic,
-        Competitive,
-        Defense
-    }
-
     public EGameMode ModeType {  get; protected set; }
     public bool GameOver { get; protected set; }
     public int CurrentRound {  get; protected set; }


### PR DESCRIPTION
Changed game mode initialization to an enum that can be changed in the inspector of the GameManager. So, when a defense mode scene is created and a GameManager is added, the gameModeType field should be set to Defense in the inspector dropdown.

Open the SampleScene and CompetativeMode scene and check to see that the field Game Mode Type is there and correctly selected.

![image](https://github.com/mythguy1226/80sgame/assets/89759400/6992e4b8-e644-49bf-87b2-3ba36851cfc6)

https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-54

Due in Sprint 1