### PR TITLE
Fixed Join Transition

### DIFF
--- a/80s Game/Assets/PlayerInput/InputActions.inputactions
+++ b/80s Game/Assets/PlayerInput/InputActions.inputactions
@@ -301,6 +301,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "StartGame",
+                    "type": "Button",
+                    "id": "fef37fb9-6255-4abf-8dd1-64a86aba59c2",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -719,6 +728,28 @@
                     "processors": "",
                     "groups": "XR",
                     "action": "TrackedDeviceOrientation",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "0aece06f-878b-4182-999e-add65c445a80",
+                    "path": "<Gamepad>/start",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "PS4",
+                    "action": "StartGame",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "d73893ff-90bb-4fd2-92a1-95adfddc3038",
+                    "path": "<Keyboard>/space",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "KnM",
+                    "action": "StartGame",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
@@ -85,6 +85,7 @@ public class PlayerController : MonoBehaviour
 
     public void EmitPause()
     {
+
         if (currentState == ControllerState.JoinScreen)
         {
             pjm.LaunchGameMode();

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
@@ -96,6 +96,11 @@ public class PlayerInputWrapper : MonoBehaviour
         player.EmitPause();
     }
 
+    private void OnStartGame(InputValue value)
+    {
+        player.EmitPause();
+    }
+
     private void OnPause()
     {
 


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Added an input mapping to the UI action map to allow for Start Game messages to be sent.

## Please describe how to test
On the Player Join screen, try joining a player and starting the game. Use the start button on a controller and space on the keyboard

## Relevant Screenshots
Added StartGame mapping
![image](https://github.com/mythguy1226/80sgame/assets/9394777/4485cdf0-ead6-4f0e-b70b-0c4fc70a3836)


## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-66

## What Sprint is this due in?
Sprint 1