### PR TITLE
Horizontal integration complete

### DIFF
--- a/80s Game/Assets/Scripts/FloatingText.cs
+++ b/80s Game/Assets/Scripts/FloatingText.cs
@@ -1,7 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Rendering.VirtualTexturing;
 
 public class FloatingText : MonoBehaviour
 {

--- a/80s Game/Assets/Scripts/GameManager.cs
+++ b/80s Game/Assets/Scripts/GameManager.cs
@@ -86,6 +86,11 @@ public class GameManager : MonoBehaviour
             default:
                 break;
         }
+        Scene activeScene = SceneManager.GetActiveScene();
+        if (activeScene.buildIndex > 1)
+        {
+            ActiveGameMode.StartGame();
+        }
     }
 
     public static void EmitRoundOverEvent()

--- a/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
@@ -13,8 +13,6 @@ public class ClassicMode : AbsGameMode
         NumRounds = 10;
         maxTargetsOnScreen = 8;
         currentRoundTargetCount = 5;
-
-        StartNextRound(true);
     }
 
     protected override void StartNextRound(bool isFirstRound = false)

--- a/80s Game/Assets/Scripts/GameModes/CompetitiveMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/CompetitiveMode.cs
@@ -14,8 +14,6 @@ public class CompetitiveMode : AbsGameMode
         NumRounds = 15;
         maxTargetsOnScreen = 15;
         currentRoundTargetCount = 8;
-
-        StartNextRound(true);
     }
 
     protected override void StartNextRound(bool isFirstRound = false)

--- a/80s Game/Assets/Scripts/GameModes/GameMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/GameMode.cs
@@ -31,6 +31,11 @@ public abstract class AbsGameMode
         CurrentRound = 1;
     }
 
+    public void StartGame()
+    {
+        StartNextRound(true);
+    }
+
     // Needs to be public for targetManager to call
     public abstract void OnTargetReset();
 

--- a/80s Game/Assets/Scripts/GameModes/GameModeData.cs
+++ b/80s Game/Assets/Scripts/GameModes/GameModeData.cs
@@ -1,0 +1,16 @@
+public static class GameModeData
+{
+    public static EGameMode activeGameMode;
+    
+
+    public static int GameModeToSceneIndex()
+    {
+        switch (activeGameMode)
+        {
+            case EGameMode.Competitive:
+                return 3;
+            default:
+                return 2;
+        }
+    }
+}

--- a/80s Game/Assets/Scripts/GameModes/GameModeData.cs.meta
+++ b/80s Game/Assets/Scripts/GameModes/GameModeData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4092e3ee9e0e7c9448401576f5e95940
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
@@ -41,6 +41,10 @@ public class PlayerJoinManager : MonoBehaviour
 
         joinPrompt.text = "Press Start when ready";
         joinPrompt.rectTransform.SetLocalPositionAndRotation(new Vector3(0, -460, 0), Quaternion.identity);
+
+        if (GameModeData.activeGameMode == EGameMode.Classic)
+        {
+            PlayerInputManager.instance.DisableJoining();        }
     }
 
     public void SetPlayerReady(int player, bool isReady)
@@ -60,6 +64,6 @@ public class PlayerJoinManager : MonoBehaviour
         }
 
         // Everyone is ready
-        SceneManager.LoadScene(3);
+        SceneManager.LoadScene(GameModeData.GameModeToSceneIndex());
     }
 }

--- a/80s Game/Assets/Scripts/SoundManager.cs
+++ b/80s Game/Assets/Scripts/SoundManager.cs
@@ -60,13 +60,12 @@ public class SoundManager : MonoBehaviour
             interruptSource.Stop(); //interrupts current sound playing through interruptSource, to avoid sounds stacking on top of one another
         }
         interruptSource.PlayOneShot(clip, volume);
-        //Debug.Log(clip);
+
     }
 
     public void PlaySoundContinuous(AudioClip clip)
     { 
         continuousSource.PlayOneShot(clip, volume);
-        //Debug.Log(clip);
     }
 
     public void StopMusicLoop()
@@ -76,7 +75,7 @@ public class SoundManager : MonoBehaviour
             if (musicLoopSources[i] == null) continue;
             musicLoopSources[i].Stop();
         }
-        Debug.Log("you have been stopped.");
+
         isMusicPlaying = false;
     }
 
@@ -85,7 +84,7 @@ public class SoundManager : MonoBehaviour
         //probably dangerous, but shouldn't need to be called anyway
         if (musicLoopSources == null || musicLoopSources.Length == 0)
         {
-            Debug.Log("");
+
             musicLoopSources = new AudioSource[2];
             musicLoopSources[0] = new AudioSource();
             musicLoopSources[0].volume = volume;
@@ -110,14 +109,14 @@ public class SoundManager : MonoBehaviour
         if (clip != null)
         {
             musicLoopClip = clip;
-            Debug.Log(clip + " has been set to loop.");
+
             nextEventTime = AudioSettings.dspTime + 1.0f;
-            Debug.Log("Next event time: " + nextEventTime);
+
             isMusicPlaying = true;
         }
         else
         {
-            Debug.Log("frick me dood, the music loop clip is null");
+
             return;
         }
     }
@@ -127,12 +126,12 @@ public class SoundManager : MonoBehaviour
     {
         if (!isMusicPlaying) //update does nothing if music is not currently playing
         {
-            //Debug.Log("Music is not playing!");
+
             return; 
         }
 
         double time = AudioSettings.dspTime;
-        //Debug.Log(time);
+
 
         if(musicLoopClip == null) //can't play music if there *is* no music
         {
@@ -144,8 +143,6 @@ public class SoundManager : MonoBehaviour
             musicLoopSources[flip].volume = volume; //update audio source volume to reflect current overall volume
             musicLoopSources[flip].clip = musicLoopClip;
             musicLoopSources[flip].PlayScheduled(nextEventTime);
-
-            Debug.Log("Scheduled source " + flip + " to start at time " + nextEventTime);
 
             nextEventTime += musicLoopClip.length;
 

--- a/80s Game/Assets/Scripts/UI Scripts/TitleScreenBehavior.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/TitleScreenBehavior.cs
@@ -25,43 +25,23 @@ public class TitleScreenBehavior : MonoBehaviour
     void Start()
     {
         SoundManager.Instance.SetMusicToLoop(titleScreenMusic);
-        Debug.Log(titleScreenMusic + " should be playing right about now...");
-        Debug.Log("Is music playing? " + SoundManager.Instance.IsMusicPlaying);
     }
 
     void Update()
     {
-        //if (!SoundManager.Instance.IsMusicPlaying)
-        //{
-        //    SoundManager.Instance.SetMusicToLoop(titleScreenMusic);
-        //    Debug.Log(titleScreenMusic + " has been executed through update instead!");
-        //}
-        //Disable joycon calibration onboarding if no joycons are connected
-        /*if (GameManager.Instance.InputManager.joycons.Count == 0)
-        {
-            onboardingPanel.SetActive(false);
-            onboardingContinueButton.SetActive(false);
-        }
 
-        //only allow user to continue after they recenter the cursor
-        else
-        {
-            Joycon j = GameManager.Instance.InputManager.joycons[GameManager.Instance.InputManager.jc_ind];
-            if (j.GetButtonDown(Joycon.Button.DPAD_DOWN))
-            {
-                onboardingContinueButton.SetActive(true);
-            }
-        }*/
 
         switch(gamemodeSelected)
         {
             case 1:
                 gamemodeName.text = "Classic";
                 gamemodeDescription.text = "The Classic Bat Bots experience.\n\nPlay through several rounds and stun as many Bat Bots as possible.\n\nTry to achieve the highest score!";
+                GameModeData.activeGameMode = EGameMode.Classic;
                 break;
             case 2:
                 gamemodeName.text = "Competitive";
                 gamemodeDescription.text = "Bat Bots with Multiplayer!\n\nPlay with up to 2 players and compete to see who can get the highest score!\n\nThis mode features new bat bots not seen in the Classic mode!";
+                GameModeData.activeGameMode = EGameMode.Competitive;
                 break;
         }
     }
@@ -73,7 +53,7 @@ public class TitleScreenBehavior : MonoBehaviour
         SoundManager.Instance.PlaySoundContinuous(buttonClickSound);
         SoundManager.Instance.StopMusicLoop();
         PlayerData.Reset();
-        SceneManager.LoadScene(gamemodeSelected);
+        SceneManager.LoadScene(1);
     }
 
     //Exits the application
@@ -81,6 +61,11 @@ public class TitleScreenBehavior : MonoBehaviour
     public void ExitGame()
     {
         SoundManager.Instance.PlaySoundContinuous(buttonClickSound);
+        if (Application.isEditor)
+        {
+            UnityEditor.EditorApplication.isPlaying = false;
+            return;
+        }
         Application.Quit();
     }
 

--- a/80s Game/ProjectSettings/EditorBuildSettings.asset
+++ b/80s Game/ProjectSettings/EditorBuildSettings.asset
@@ -9,15 +9,12 @@ EditorBuildSettings:
     path: Assets/Scenes/TitleScreen.unity
     guid: ad65f6e8882d1764c82e60e286ec2920
   - enabled: 1
-    path: Assets/Scenes/SampleScene.unity
-    guid: 2cda990e2423bbf4892e6590ba056729
-  - enabled: 1
     path: Assets/Scenes/JoinScene.unity
     guid: 9b92ff48492d87643adb64930541cd43
   - enabled: 1
+    path: Assets/Scenes/SampleScene.unity
+    guid: 2cda990e2423bbf4892e6590ba056729
+  - enabled: 1
     path: Assets/Scenes/CompetitiveMode.unity
     guid: 295102dbda47b644db513e23df3d5202
-  - enabled: 0
-    path: Assets/Scenes/Eduardo-NewInputSystem.unity
-    guid: 95ceef5f075313845866b2490af4c313
   m_configObjects: {}


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Made it so game modes no longer immediately launch round one in the constructor
Created a static GameMode data manager
Limited player joining if on classic mode to single player only
Also, cleaned up a bunch of Debug logs

## Please describe how to test
Launch from the Title Screen
Try playing classic - play to the end.
Return to menu _THROUGH_ the in-game options. **Do not stop the game in editor to do this**
Try playing competitive - play to the end.

This should all work without a hitch.

## Relevant Screenshots
No way to really show horizontal integration

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-74

## What Sprint is this due in?
Sprint 1