### PR TITLE
Changed reset behavior on flee state

### DIFF
--- a/80s Game/Assets/Scripts/AI/StateMachine/BaseBat/FleeingState.cs
+++ b/80s Game/Assets/Scripts/AI/StateMachine/BaseBat/FleeingState.cs
@@ -49,7 +49,7 @@ public class FleeingState : AbsBaseState<BatStateMachine.BatStates>
 
 
         // Check if destination is reached
-        if (_MovementControls.IsAtDestination())
+        if (!_MovementControls.IsInsideScreen())
             FSM.Reset();
     }
 

--- a/80s Game/Assets/Scripts/KinematicSteer.cs
+++ b/80s Game/Assets/Scripts/KinematicSteer.cs
@@ -151,6 +151,12 @@ public class KinematicSteer : MonoBehaviour
         return distance <= targetRadius;
     }
 
+    public bool IsInsideScreen()
+    {
+        Vector3 screenPoint = Camera.main.WorldToViewportPoint(transform.position);
+        return screenPoint.x > 0 && screenPoint.y > 0 && screenPoint.x < 1 && screenPoint.y < 1;
+    }
+
     // Method for applying flocking
     public void Flock()
     {


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Changed the flee state to test whether a bat is outside the screen in order to reset rather than waiting for bats to reach a despawn point. This has removed potential flocking interference with resetting, which in turn eliminates softlocking.

## Please describe how to test
Play competitive mode to the end.
Should work fine.

## Relevant Screenshots
Look at these goofballs, smh
![image](https://github.com/mythguy1226/80sgame/assets/9394777/4fbfdbfc-39b7-474a-9dcc-2bda9cf41ca1)


## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-76

## What Sprint is this due in?
Sprint 1