### PR TITLE
Fix bonus points growing absurdly when players don't shoot

### DIFF
--- a/80s Game/Assets/Scripts/GameManager.cs
+++ b/80s Game/Assets/Scripts/GameManager.cs
@@ -96,5 +96,6 @@ public class GameManager : MonoBehaviour
     public static void EmitRoundOverEvent()
     {
         roundOverObservers?.Invoke();
+        GameManager.Instance.PointsManager.ResetRoundPoints();
     }
 }

--- a/80s Game/Assets/Scripts/PointsManager.cs
+++ b/80s Game/Assets/Scripts/PointsManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using UnityEngine;
 
 public class PointsManager : MonoBehaviour
@@ -72,7 +73,7 @@ public class PointsManager : MonoBehaviour
 
     public void ResetRoundPoints()
     {
-        foreach(int key in RoundScoreByPlayer.Keys)
+        foreach(int key in RoundScoreByPlayer.Keys.ToList())
         {
             RoundScoreByPlayer[key] = 0;
         }

--- a/80s Game/Assets/Scripts/PointsManager.cs
+++ b/80s Game/Assets/Scripts/PointsManager.cs
@@ -70,6 +70,14 @@ public class PointsManager : MonoBehaviour
         return AddRoundPoints(player, numBonusPoints);
     }
 
+    public void ResetRoundPoints()
+    {
+        foreach(int key in RoundScoreByPlayer.Keys)
+        {
+            RoundScoreByPlayer[key] = 0;
+        }
+    }
+
     public class UserRecord
     {
         public string initials;


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Players could just continue to double their points by not shooting

## Please describe how to test
Play the game. Score some points in round one.
Stop shooting.

Points should not accumulate after round 1.

## Relevant Screenshots


## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-80

## What Sprint is this due in?
Sprint 1