### PR TITLE
Fixed several Join Screen bugs

### DIFF
--- a/80s Game/Assets/Scenes/JoinScene.unity
+++ b/80s Game/Assets/Scenes/JoinScene.unity
@@ -546,7 +546,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 2089025913}
         m_TargetAssemblyTypeName: PlayerJoinManager, Assembly-CSharp
-        m_MethodName: BackOut
+        m_MethodName: CloseBackOutPanel
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1439,7 +1439,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &896746943
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
@@ -126,7 +126,7 @@ public class PlayerController : MonoBehaviour
     {
         if (currentState == ControllerState.JoinScreen)
         {
-            pjm.BackOut();
+            pjm.BackOut(Order);
         }
     }
 

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
@@ -24,6 +24,9 @@ public class PlayerJoinManager : MonoBehaviour
     public List<Sprite> controllerInputPrompts;
     public List<Sprite> keyboardInputPrompts;
 
+    private GameObject lastSelected = null;
+    private int backOutPlayerRef;
+
 
     private void Awake()
     {
@@ -114,21 +117,64 @@ public class PlayerJoinManager : MonoBehaviour
         SceneManager.LoadScene(GameModeData.GameModeToSceneIndex());
     }
 
-    public void BackOut()
+    public void BackOut(int playerIndex)
     {
         backOutPanel.SetActive(!backOutPanel.activeInHierarchy);
-        TogglePanelControls();
-
+        //TogglePanelControls();
         if (backOutPanel.activeInHierarchy)
         {
-            EventSystem.current.SetSelectedGameObject(null);
-            EventSystem.current.SetSelectedGameObject(backOutExit);
+            int childIndex = 0;
+            foreach (Transform child in joinPanelContainer.transform)
+            {
+                if (childIndex == playerIndex)
+                {
+                    backOutPlayerRef = childIndex;
+                    MultiplayerEventSystem eventSystem = child.GetChild(0).GetComponent<MultiplayerEventSystem>();
+                    lastSelected = eventSystem.currentSelectedGameObject;
+
+                    Debug.Log(lastSelected);
+                    eventSystem.playerRoot = backOutPanel;
+                    eventSystem.SetSelectedGameObject(null);
+                    eventSystem.SetSelectedGameObject(backOutExit);
+                }
+
+                else
+                {
+                    child.GetChild(0).gameObject.SetActive(false);
+                }
+
+                childIndex++;
+            }
         }
 
         else
         {
-            EventSystem.current.SetSelectedGameObject(null);
+            CloseBackOutPanel();
         }
+    }
+
+    public void CloseBackOutPanel()
+    {
+        backOutPanel.SetActive(false);
+
+        int childIndex = 0;
+            foreach (Transform child in joinPanelContainer.transform)
+            {
+                if (childIndex == backOutPlayerRef)
+                {                
+                    MultiplayerEventSystem eventSystem = child.GetChild(0).GetComponent<MultiplayerEventSystem>();
+                    eventSystem.playerRoot = child.gameObject;
+                    eventSystem.SetSelectedGameObject(null);
+                    eventSystem.SetSelectedGameObject(lastSelected);
+                }
+
+                else
+                {
+                    child.GetChild(0).gameObject.SetActive(true);
+                }
+
+                childIndex++;
+            }
     }
 
     public void ExitToTitle()
@@ -138,9 +184,6 @@ public class PlayerJoinManager : MonoBehaviour
 
     public void TogglePanelControls()
     {
-        foreach (Transform child in joinPanelContainer.transform)
-        {
-            child.GetChild(0).gameObject.SetActive(!child.GetChild(0).gameObject.activeInHierarchy);
-        }
+        
     }
 }

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
@@ -119,27 +119,36 @@ public class PlayerJoinManager : MonoBehaviour
 
     public void BackOut(int playerIndex)
     {
+        //Toggle the back out panel
         backOutPanel.SetActive(!backOutPanel.activeInHierarchy);
-        //TogglePanelControls();
+
+        //If the panel is active
         if (backOutPanel.activeInHierarchy)
         {
+            //Loop through all the join panels and keep track of the index
             int childIndex = 0;
             foreach (Transform child in joinPanelContainer.transform)
             {
+                //If the panel matches the player who clicked the exit button
                 if (childIndex == playerIndex)
                 {
+                    //Set player ref
                     backOutPlayerRef = childIndex;
+
+                    //Change player root for their event system and set their last selected game object
                     MultiplayerEventSystem eventSystem = child.GetChild(0).GetComponent<MultiplayerEventSystem>();
                     lastSelected = eventSystem.currentSelectedGameObject;
-
-                    Debug.Log(lastSelected);
                     eventSystem.playerRoot = backOutPanel;
+
+                    //Set the new selected object to the exit button on the back out panel
                     eventSystem.SetSelectedGameObject(null);
                     eventSystem.SetSelectedGameObject(backOutExit);
                 }
 
+                //If the player didn't hit the exit button
                 else
-                {
+                {   
+                    //Disable their inputs but deactivating their event system
                     child.GetChild(0).gameObject.SetActive(false);
                 }
 
@@ -147,6 +156,7 @@ public class PlayerJoinManager : MonoBehaviour
             }
         }
 
+        //If the back out panel isn't active, close it
         else
         {
             CloseBackOutPanel();
@@ -155,35 +165,38 @@ public class PlayerJoinManager : MonoBehaviour
 
     public void CloseBackOutPanel()
     {
+        //Turn off the panel
         backOutPanel.SetActive(false);
 
         int childIndex = 0;
-            foreach (Transform child in joinPanelContainer.transform)
-            {
-                if (childIndex == backOutPlayerRef)
-                {                
-                    MultiplayerEventSystem eventSystem = child.GetChild(0).GetComponent<MultiplayerEventSystem>();
-                    eventSystem.playerRoot = child.gameObject;
-                    eventSystem.SetSelectedGameObject(null);
-                    eventSystem.SetSelectedGameObject(lastSelected);
-                }
 
-                else
-                {
-                    child.GetChild(0).gameObject.SetActive(true);
-                }
+        //Loop through all the join panels
+        foreach (Transform child in joinPanelContainer.transform)
+        {
+            //If the panel matches the player that has control of the back out panel
+            if (childIndex == backOutPlayerRef)
+            {           
+                //Set their player root back to their join panel     
+                MultiplayerEventSystem eventSystem = child.GetChild(0).GetComponent<MultiplayerEventSystem>();
+                eventSystem.playerRoot = child.gameObject;
 
-                childIndex++;
+                //Set their selected object back to what it was when they hit exit
+                eventSystem.SetSelectedGameObject(null);
+                eventSystem.SetSelectedGameObject(lastSelected);
             }
+
+            //If the panel isn't for the player that hit exit, reactivate their controls
+            else
+            {
+                child.GetChild(0).gameObject.SetActive(true);
+            }
+
+            childIndex++;
+        }
     }
 
     public void ExitToTitle()
     {
         SceneManager.LoadScene(0);
-    }
-
-    public void TogglePanelControls()
-    {
-        
     }
 }


### PR DESCRIPTION
## Summarize what is being added
-The back out panel for the Join Screen should now work as intended without causing any other issues
-The back out panel can only be used and navigated by the player who brought up the panel

## Please describe how to test
-Start the title screen and start Competitive mode
-Join with two players, then hit the exit button to go back to the title screen
-Only the controller who hit exit should be able to navigate the back out prompt
-Cancel the prompt and the join screen should continue to work as intended
-Exit using the other controller to ensure both cases work

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-84

## What Sprint is this due in?
Sprint 2