### PR TITLE
Fixed loading multiple scenes on Loading Screen

### DIFF
--- a/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
@@ -27,6 +27,7 @@ public class PlayerJoinManager : MonoBehaviour
     private GameObject lastSelected = null;
     private int backOutPlayerRef;
     private bool controllerConnected;
+    private bool sceneTransition = false;
 
 
     private void Awake()
@@ -115,8 +116,6 @@ public class PlayerJoinManager : MonoBehaviour
                 return;
             }
         }
-        
-        bool sceneTransition = false;
 
         if (!sceneTransition)
         {


### PR DESCRIPTION
## Summarize what is being added
Fixed a bug where multiple scenes could be loaded when on the loading screen

## Please describe how to test
-Start the Join Scene and start the game, when on the loading screen there should be a scene in the inspector that says (is loading)
-Press the start game again while in the loading screen, no other scenes should appear with (is loading) in the inspector
-The scene should load as normal when pressing start on the loading screen

## Relevant Screenshots
![image](https://github.com/mythguy1226/80sgame/assets/70411851/e41f5f55-153a-4059-bd38-d2b36f1e90ff)

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-138

## What Sprint is this due in?
Sprint 2