### PR TITLE
Replaced modifier UI indicators with animated prefabs

### DIFF
--- a/80s Game/Assets/Prefabs/Modifiers/Confusion.prefab
+++ b/80s Game/Assets/Prefabs/Modifiers/Confusion.prefab
@@ -33,10 +33,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 65, y: 65}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1842755478585497755
 CanvasRenderer:
@@ -67,7 +67,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: -2669561656170236770, guid: bee3a2aa6d4d5614eb61cb21ca2943b6, type: 3}
-  m_Type: 0
+  m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4

--- a/80s Game/Assets/Prefabs/Modifiers/ConfusionMod.prefab
+++ b/80s Game/Assets/Prefabs/Modifiers/ConfusionMod.prefab
@@ -162,4 +162,4 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   effectDuration: 10
-  modifierUIPrefab: {fileID: 4742045415562882795, guid: c6bcdacb154613049b3a43866d7df7f9, type: 3}
+  modifierUIPrefab: {fileID: 8934627380610990763, guid: 8db0b1d577046204a9a74e1078d9ae3d, type: 3}

--- a/80s Game/Assets/Prefabs/Modifiers/OcMod.prefab
+++ b/80s Game/Assets/Prefabs/Modifiers/OcMod.prefab
@@ -162,5 +162,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   effectDuration: 10
-  modifierUIPrefab: {fileID: 4742045415562882795, guid: 3052070908cd69d4896cc1da560f9e8d, type: 3}
+  modifierUIPrefab: {fileID: 2369580833882870520, guid: 7de7a0df7195efc4d913b933d983ceb7, type: 3}
   hitParticles: {fileID: 3537340124483570280, guid: 7f86aa82b0946c7498238b9fe89ac5aa, type: 3}

--- a/80s Game/Assets/Prefabs/Modifiers/Overcharged.prefab
+++ b/80s Game/Assets/Prefabs/Modifiers/Overcharged.prefab
@@ -33,10 +33,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 65, y: 65}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3727389499244061661
 CanvasRenderer:
@@ -67,7 +67,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: -160843341645564060, guid: 5885ab52b26256e47ada146a0e3b8b06, type: 3}
-  m_Type: 0
+  m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4

--- a/80s Game/Assets/Prefabs/Modifiers/SnailMod.prefab
+++ b/80s Game/Assets/Prefabs/Modifiers/SnailMod.prefab
@@ -162,4 +162,4 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   effectDuration: 10
-  modifierUIPrefab: {fileID: 4742045415562882795, guid: 16c69c583dba2b14e96de16095936728, type: 3}
+  modifierUIPrefab: {fileID: 2011110001720158753, guid: 36d6513b4ab389e45a3d1ca3abb6c42b, type: 3}

--- a/80s Game/Assets/Prefabs/Modifiers/SnailPace.prefab
+++ b/80s Game/Assets/Prefabs/Modifiers/SnailPace.prefab
@@ -33,10 +33,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 65, y: 65}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8689718131850836809
 CanvasRenderer:
@@ -67,7 +67,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: -8084252441760017413, guid: 433cf014f4ec07440b18fd6ba1913105, type: 3}
-  m_Type: 0
+  m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4


### PR DESCRIPTION
## Summarize what is being added
-Replaced the modifier UI prefabs for Overcharge, Confusion, and Snail's Pace with animated prefabs

## Please describe how to test
-Play competitive mode and get each of the modifiers, they should all show animated UI indicators when they are active

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-104

## What Sprint is this due in?
Sprint 2