### PR TITLE
Restrict competitive mode to not allow 1 player

### DIFF
--- a/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
@@ -116,6 +116,12 @@ public class PlayerJoinManager : MonoBehaviour
     // This function launches the corresponding game mode that has been loaded by selection in the previous scene.
     public void LaunchGameMode()
     {
+        //Don't launch competitive with only 1 player
+        if (GameModeData.activeGameMode == EGameMode.Competitive && PlayerData.activePlayers.Count == 1)
+        {
+            return;
+        }
+
         foreach(KeyValuePair<int, bool> kvp in joinStatus)
         {
             if (!kvp.Value)


### PR DESCRIPTION
## Summarize what is being added
-Competitive Mode can no longer be started with only 1 player joined
-This is done due to competitive mode with 1 player offering little to no differences to Classic Mode (also since some modifiers don't do anything with only 1 player active)

## Please describe how to test
-Launch the game and load into competitive mode. Join with 1 player and ready up, then hit the start button. The game should NOT transition unless 2 or more players are in the game and readied up

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-146

## What Sprint is this due in?
Sprint 2