### PR TITLE
Implemented modifier pooling per game mode

### DIFF
--- a/80s Game/Assets/Scenes/CompetitiveMode.unity
+++ b/80s Game/Assets/Scenes/CompetitiveMode.unity
@@ -6840,6 +6840,12 @@ MonoBehaviour:
   gameModeType: 1
   isSlowed: 0
   debuffActive: 0
+  buffs:
+  - {fileID: 55702376141867145, guid: 9b8df211c79ba59479819337f0c946e2, type: 3}
+  - {fileID: 55702376141867145, guid: 6311858a13f90b740a1313dc1b64b33d, type: 3}
+  debuffs:
+  - {fileID: 55702376141867145, guid: 367a188d6de1eb74aa7ebbdba130f295, type: 3}
+  - {fileID: 55702376141867145, guid: 1711ae630a5eadd4c811d1c70c1e9b7b, type: 3}
   debug: 1
 --- !u!4 &1095139975
 Transform:

--- a/80s Game/Assets/Scenes/SampleScene.unity
+++ b/80s Game/Assets/Scenes/SampleScene.unity
@@ -2697,6 +2697,137 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 43ff5eb187dcf274b93709103d6ab629, type: 3}
+--- !u!1 &454436789
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 454436790}
+  - component: {fileID: 454436795}
+  - component: {fileID: 454436794}
+  - component: {fileID: 454436793}
+  - component: {fileID: 454436792}
+  - component: {fileID: 454436791}
+  m_Layer: 5
+  m_Name: P1 Status Effects
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &454436790
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 454436789}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.0000799, y: 1.0000799, z: 1.0000799}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1554343129}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: -137.5128, y: 7.3005066}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 1, y: 1}
+--- !u!114 &454436791
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 454436789}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 1
+  m_VerticalFit: 1
+--- !u!114 &454436792
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 454436789}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 7
+  m_Spacing: 15
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &454436793
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 454436789}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 0
+--- !u!114 &454436794
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 454436789}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &454436795
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 454436789}
+  m_CullTransparentMesh: 1
 --- !u!1 &455586617
 GameObject:
   m_ObjectHideFlags: 0
@@ -3323,6 +3454,63 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519642956}
   m_CullTransparentMesh: 1
+--- !u!1001 &523252512
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 232502045716647642, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_Name
+      value: ModifierBat (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 28.36
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.090761
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
 --- !u!1 &537532382
 GameObject:
   m_ObjectHideFlags: 0
@@ -3922,6 +4110,63 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 43ff5eb187dcf274b93709103d6ab629, type: 3}
+--- !u!1001 &665874769
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 232502045716647642, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_Name
+      value: ModifierBat (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 28.36
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 8.343187
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
 --- !u!1001 &691513407
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5231,6 +5476,7 @@ MonoBehaviour:
   highScoreTextObject: {fileID: 153801723}
   finalScoreTextObject: {fileID: 1117114116}
   roundIndicatorTextObject: {fileID: 736886330}
+  playerNames: []
 --- !u!114 &1011990667
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5280,6 +5526,63 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 885baa7af02d6ca40a430cf4db00a272, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &1012532306
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 232502045716647642, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_Name
+      value: ModifierBat
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 26.258446
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 8.343187
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
 --- !u!1 &1028283567
 GameObject:
   m_ObjectHideFlags: 0
@@ -5717,6 +6020,10 @@ MonoBehaviour:
   gameModeType: 0
   isSlowed: 0
   debuffActive: 0
+  buffs:
+  - {fileID: 55702376141867145, guid: 9b8df211c79ba59479819337f0c946e2, type: 3}
+  - {fileID: 55702376141867145, guid: 6311858a13f90b740a1313dc1b64b33d, type: 3}
+  debuffs: []
   debug: 1
 --- !u!4 &1095139975
 Transform:
@@ -5747,7 +6054,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   activeUI: 1
   canvas: {fileID: 1011990661}
-  modifierContainers: []
+  modifierContainers:
+  - {fileID: 454436789}
 --- !u!114 &1095139977
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7098,6 +7406,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 470208379}
+  - {fileID: 454436790}
   m_Father: {fileID: 1759806106}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -7705,6 +8014,63 @@ RectTransform:
   m_AnchoredPosition: {x: 261, y: 57}
   m_SizeDelta: {x: 121.9048, y: 82.4922}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &1592864829
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 232502045716647642, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_Name
+      value: ModifierBat (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 26.258446
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.090761
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 441829429701910797, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8ebe54834c1d24045ac1e8e5ae441030, type: 3}
 --- !u!1 &1605621740
 GameObject:
   m_ObjectHideFlags: 0
@@ -11005,3 +11371,7 @@ SceneRoots:
   - {fileID: 947073195}
   - {fileID: 1137455541}
   - {fileID: 1629341530}
+  - {fileID: 1012532306}
+  - {fileID: 523252512}
+  - {fileID: 665874769}
+  - {fileID: 1592864829}

--- a/80s Game/Assets/Scripts/AI/StateMachine/ModifierBat/ModifierBatStateMachine.cs
+++ b/80s Game/Assets/Scripts/AI/StateMachine/ModifierBat/ModifierBatStateMachine.cs
@@ -6,9 +6,19 @@ using Random = UnityEngine.Random;
 public class ModifierBatStateMachine : BatStateMachine
 {
     // Public modifier fields
-    public List<GameObject> buffs;
-    public List<GameObject> debuffs;
+    List<GameObject> buffs;
+    List<GameObject> debuffs;
     bool modifierDropped = false;
+
+    /// <summary>
+    /// Override: Start method
+    /// </summary>
+    void Start()
+    {
+        // Get buffs and debuffs from game manager
+        buffs = GameManager.Instance.buffs;
+        debuffs = GameManager.Instance.debuffs;
+    }
 
     /// <summary>
     /// Override: Checks if target has been stunned

--- a/80s Game/Assets/Scripts/GameManager.cs
+++ b/80s Game/Assets/Scripts/GameManager.cs
@@ -26,6 +26,8 @@ public class GameManager : MonoBehaviour
     public UIManager UIManager { get; private set; }
     public bool isSlowed = false;
     public bool debuffActive = false;
+    public List<GameObject> buffs;
+    public List<GameObject> debuffs;
     
     [Tooltip("Debug to spawn a Player Controller for testing without having to go through the join screen")]
     public bool debug;

--- a/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
@@ -35,10 +35,6 @@ public class ClassicMode : AbsGameMode
             if (targetManager.ActiveTargets.Count == maxTargetsOnScreen)
                 return;
         }
-
-        // Spawn a modifier bat and increment target count
-        targetManager.SpawnTarget(targetManager.GetNextAvailableTargetOfType<ModifierBatStateMachine>());
-        currentRoundTargetCount++;
     }
 
     protected override void UpdateRoundParams()
@@ -108,6 +104,9 @@ public class ClassicMode : AbsGameMode
             {
                 GameManager.EmitRoundOverEvent();
                 StartNextRound();
+                // Spawn a modifier bat and increment target count
+                targetManager.SpawnTarget(targetManager.GetNextAvailableTargetOfType<ModifierBatStateMachine>());
+                currentRoundTargetCount++;
             }
                 
 

--- a/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
@@ -35,6 +35,10 @@ public class ClassicMode : AbsGameMode
             if (targetManager.ActiveTargets.Count == maxTargetsOnScreen)
                 return;
         }
+
+        // Spawn a modifier bat and increment target count
+        targetManager.SpawnTarget(targetManager.GetNextAvailableTargetOfType<ModifierBatStateMachine>());
+        currentRoundTargetCount++;
     }
 
     protected override void UpdateRoundParams()
@@ -65,6 +69,10 @@ public class ClassicMode : AbsGameMode
             if (bats[i].FSM.bIsActive)
                 continue;
 
+            ModifierBatStateMachine comp = bats[i].GetComponent<ModifierBatStateMachine>();
+            if (comp != null)
+                continue;
+                
             // If default bat, return index if no bonus bats
             // Otherwise continue
             if (bats[i].FSM.IsDefault && numBonusBats == 0)


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
- Implemented modifier bat spawn logic in classic mode
- Modifier pool for game mode is now stored in game manager for modifier bats to pull from

## Please describe how to test
Play classic game mode and there should now be modifier bats for you to stun! Only two buffs available currently are double points and overcharged due to it being single player. Also test competitive mode to ensure it functions as expected.

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-101

## What Sprint is this due in?
Sprint 2