### PR TITLE
Default Crosshair Colors & Readjusted Join Screen Process

### DIFF
--- a/80s Game/Assets/Prefabs/PlayerControllers/PlayerPanel.prefab
+++ b/80s Game/Assets/Prefabs/PlayerControllers/PlayerPanel.prefab
@@ -393,7 +393,7 @@ MonoBehaviour:
     m_Mode: 4
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 5892455636561808030}
-    m_SelectOnDown: {fileID: 3976664850607898538}
+    m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 8193486034410197589}
   m_Transition: 1
@@ -586,7 +586,7 @@ MonoBehaviour:
     m_Mode: 4
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 4427111538498517673}
-    m_SelectOnDown: {fileID: 3976664850607898538}
+    m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 2575396125069112618}
     m_SelectOnRight: {fileID: 2506923754732081274}
   m_Transition: 1
@@ -936,7 +936,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2126817647660215973}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -945,7 +945,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.0000038147, y: 305}
+  m_AnchoredPosition: {x: 0, y: 305}
   m_SizeDelta: {x: 334.7538, y: 45.7446}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5676826840060594197
@@ -1181,211 +1181,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &2501266982530912151
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8254912148338884528}
-  - component: {fileID: 6711939981169156701}
-  - component: {fileID: 8351347569087215022}
-  - component: {fileID: 3976664850607898538}
-  - component: {fileID: 8435385887743003672}
-  m_Layer: 5
-  m_Name: Ready Up Button
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &8254912148338884528
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2501266982530912151}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7824293091794922362}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -32, y: -290}
-  m_SizeDelta: {x: 228.865, y: 45.7446}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &6711939981169156701
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2501266982530912151}
-  m_CullTransparentMesh: 1
---- !u!114 &8351347569087215022
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2501266982530912151}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Ready
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
-  m_sharedMaterial: {fileID: -507269567956872517, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 45.7
-  m_fontSizeBase: 36
-  m_fontWeight: 400
-  m_enableAutoSizing: 1
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!114 &3976664850607898538
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2501266982530912151}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 4
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 2575396125069112618}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 1, g: 0, b: 0, a: 1}
-    m_PressedColor: {r: 0.6509804, g: 0, b: 0, a: 1}
-    m_SelectedColor: {r: 0.6509804, g: 0, b: 0, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 8351347569087215022}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 7824094029749271741}
-        m_TargetAssemblyTypeName: PlayerJoinPanel, Assembly-CSharp
-        m_MethodName: ReadyUp
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
---- !u!114 &8435385887743003672
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2501266982530912151}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3a057874a223fd04b8bdd6145686d1b0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  selectable: {fileID: 3976664850607898538}
 --- !u!1 &2530687803439132509
 GameObject:
   m_ObjectHideFlags: 0
@@ -1624,7 +1419,6 @@ RectTransform:
   m_Children:
   - {fileID: 6510617060975281898}
   - {fileID: 7824293091794922362}
-  - {fileID: 3171190544866209384}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -1719,12 +1513,10 @@ MonoBehaviour:
   - {fileID: 2575396125069112618}
   - {fileID: 8193486034410197589}
   - {fileID: 2506923754732081274}
-  readyIndicator: {fileID: 4855509470559998913}
-  notReady: {fileID: 21300000, guid: afa7752f7bc592a4aa8d0b34b4b1775e, type: 3}
-  isReady: {fileID: 21300000, guid: 6890824ae2288ee40bb0fff4662cceae, type: 3}
+  playerSettings: {fileID: 8122756102008055483}
+  readyUpPrompt: {fileID: 4765379388570238239}
   playerReady: 0
   eventSystem: {fileID: 6611612375465591994}
-  player: {fileID: 0}
 --- !u!1 &2841465347351474934
 GameObject:
   m_ObjectHideFlags: 0
@@ -2299,7 +2091,7 @@ RectTransform:
   - {fileID: 553715573690257819}
   - {fileID: 7402525170743840982}
   - {fileID: 8040616726887598058}
-  m_Father: {fileID: 4077288671678105081}
+  m_Father: {fileID: 7446761421943290921}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2944,7 +2736,7 @@ MonoBehaviour:
     m_Mode: 4
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 8343765224356483661}
-    m_SelectOnDown: {fileID: 3976664850607898538}
+    m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 8193486034410197589}
     m_SelectOnRight: {fileID: 0}
   m_Transition: 1
@@ -2985,6 +2777,142 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   selectable: {fileID: 2506923754732081274}
+--- !u!1 &4765379388570238239
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7874659533343560291}
+  - component: {fileID: 7375888866237917321}
+  - component: {fileID: 1184515819111031739}
+  m_Layer: 5
+  m_Name: Readied Up
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &7874659533343560291
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4765379388570238239}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2101573674236285563}
+  - {fileID: 4129094765836835248}
+  m_Father: {fileID: 7824293091794922362}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 66}
+  m_SizeDelta: {x: 334.7538, y: 45.7446}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7375888866237917321
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4765379388570238239}
+  m_CullTransparentMesh: 1
+--- !u!114 &1184515819111031739
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4765379388570238239}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: READY!
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
+  m_sharedMaterial: {fileID: -507269567956872517, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 45.7
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &5109968904788885201
 GameObject:
   m_ObjectHideFlags: 0
@@ -3647,13 +3575,8 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8308918574622344191}
-  - {fileID: 3095629072849959993}
-  - {fileID: 7232218446913495845}
-  - {fileID: 3348825780297356346}
-  - {fileID: 1823864777322114819}
-  - {fileID: 5025071110940089269}
-  - {fileID: 8254912148338884528}
-  - {fileID: 3251442305294022187}
+  - {fileID: 7874659533343560291}
+  - {fileID: 7446761421943290921}
   m_Father: {fileID: 4077288671678105081}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -3731,11 +3654,11 @@ RectTransform:
   m_Children:
   - {fileID: 131256089917774027}
   - {fileID: 2737205381506375214}
-  m_Father: {fileID: 7824293091794922362}
+  m_Father: {fileID: 7446761421943290921}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -104}
+  m_AnchoredPosition: {x: 0, y: -154}
   m_SizeDelta: {x: 58.7705, y: 72.1971}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3415250817803906542
@@ -3971,7 +3894,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6156375346527895471}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -3979,7 +3902,7 @@ RectTransform:
   - {fileID: 4579680587399880849}
   - {fileID: 5759006145157892610}
   - {fileID: 3187762318090962988}
-  m_Father: {fileID: 7824293091794922362}
+  m_Father: {fileID: 7446761421943290921}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4024,6 +3947,211 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6212913988271144732
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4129094765836835248}
+  - component: {fileID: 1885010132326807292}
+  - component: {fileID: 3866520849997977510}
+  - component: {fileID: 7603618454058536808}
+  - component: {fileID: 3547264336531317752}
+  m_Layer: 5
+  m_Name: Cancel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4129094765836835248
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6212913988271144732}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7874659533343560291}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.000010133, y: -267}
+  m_SizeDelta: {x: 356.07, y: 34.717}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1885010132326807292
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6212913988271144732}
+  m_CullTransparentMesh: 1
+--- !u!114 &3866520849997977510
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6212913988271144732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Cancel
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
+  m_sharedMaterial: {fileID: -507269567956872517, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 34.7
+  m_fontSizeBase: 26
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &7603618454058536808
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6212913988271144732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 4
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 1, g: 0, b: 0, a: 1}
+    m_PressedColor: {r: 0.6509804, g: 0, b: 0, a: 1}
+    m_SelectedColor: {r: 0.6509804, g: 0, b: 0, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 3866520849997977510}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7824094029749271741}
+        m_TargetAssemblyTypeName: PlayerJoinPanel, Assembly-CSharp
+        m_MethodName: ReadyUp
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &3547264336531317752
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6212913988271144732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3a057874a223fd04b8bdd6145686d1b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  selectable: {fileID: 7603618454058536808}
 --- !u!1 &6392108319754378298
 GameObject:
   m_ObjectHideFlags: 0
@@ -4593,11 +4721,11 @@ RectTransform:
   m_Children:
   - {fileID: 47955680937047236}
   - {fileID: 9113612467827994424}
-  m_Father: {fileID: 7824293091794922362}
+  m_Father: {fileID: 7446761421943290921}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 80, y: -104.000015}
+  m_AnchoredPosition: {x: 80, y: -154.00002}
   m_SizeDelta: {x: 58.7705, y: 72.1971}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3024082544273952986
@@ -5221,7 +5349,7 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &7334706479482612846
+--- !u!1 &7610402126145666762
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5229,50 +5357,50 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 3251442305294022187}
-  - component: {fileID: 837777551865290104}
-  - component: {fileID: 4855509470559998913}
+  - component: {fileID: 2101573674236285563}
+  - component: {fileID: 5157035590612562653}
+  - component: {fileID: 2862010490691256487}
   m_Layer: 5
-  m_Name: Ready Indicator
+  m_Name: Image (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &3251442305294022187
+--- !u!224 &2101573674236285563
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7334706479482612846}
+  m_GameObject: {fileID: 7610402126145666762}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 7824293091794922362}
+  m_Father: {fileID: 7874659533343560291}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 143.15, y: -290}
-  m_SizeDelta: {x: 67.5354, y: 66.3931}
-  m_Pivot: {x: 0.5000001, y: 0.5}
---- !u!222 &837777551865290104
+  m_AnchoredPosition: {x: 0, y: -84}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5157035590612562653
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7334706479482612846}
+  m_GameObject: {fileID: 7610402126145666762}
   m_CullTransparentMesh: 1
---- !u!114 &4855509470559998913
+--- !u!114 &2862010490691256487
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7334706479482612846}
+  m_GameObject: {fileID: 7610402126145666762}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
@@ -5286,7 +5414,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: afa7752f7bc592a4aa8d0b34b4b1775e, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 6890824ae2288ee40bb0fff4662cceae, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -5444,11 +5572,11 @@ RectTransform:
   m_Children:
   - {fileID: 7437035704967246017}
   - {fileID: 915627021785587900}
-  m_Father: {fileID: 7824293091794922362}
+  m_Father: {fileID: 7446761421943290921}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -80, y: -104}
+  m_AnchoredPosition: {x: -80, y: -154}
   m_SizeDelta: {x: 58.7705, y: 72.1971}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7961705910659584283
@@ -5580,11 +5708,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 7824293091794922362}
+  m_Father: {fileID: 7446761421943290921}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.000010133, y: 53}
+  m_AnchoredPosition: {x: 0.000010133, y: 39}
   m_SizeDelta: {x: 356.07, y: 34.717}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1199497250672406020
@@ -5903,6 +6031,47 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8122756102008055483
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7446761421943290921}
+  m_Layer: 5
+  m_Name: Settings
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7446761421943290921
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8122756102008055483}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3095629072849959993}
+  - {fileID: 7232218446913495845}
+  - {fileID: 3348825780297356346}
+  - {fileID: 1823864777322114819}
+  - {fileID: 5025071110940089269}
+  - {fileID: 3171190544866209384}
+  m_Father: {fileID: 7824293091794922362}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &8460730466842772192
 GameObject:
   m_ObjectHideFlags: 0

--- a/80s Game/Assets/Scenes/JoinScene.unity
+++ b/80s Game/Assets/Scenes/JoinScene.unity
@@ -687,7 +687,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -895.4, y: 8.8}
+  m_AnchoredPosition: {x: -887, y: 8.8}
   m_SizeDelta: {x: 90, y: 90}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &141723225
@@ -1382,81 +1382,6 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 345663044}
-  m_CullTransparentMesh: 1
---- !u!1 &345740092
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 345740093}
-  - component: {fileID: 345740095}
-  - component: {fileID: 345740094}
-  m_Layer: 5
-  m_Name: Start Prompt
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &345740093
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 345740092}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1990815587}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 309.6, y: 8.8}
-  m_SizeDelta: {x: 90, y: 90}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &345740094
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 345740092}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: -566201383, guid: bf6e8dd2c43aefa4994607acbd9ab97b, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &345740095
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 345740092}
   m_CullTransparentMesh: 1
 --- !u!1 &348447723
 GameObject:
@@ -2170,7 +2095,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -347.9, y: 8.8}
+  m_AnchoredPosition: {x: 147, y: 8.8}
   m_SizeDelta: {x: 90, y: 90}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &591647598
@@ -3225,7 +3150,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -627, y: 8.8}
+  m_AnchoredPosition: {x: -230, y: 8.8}
   m_SizeDelta: {x: 90, y: 90}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1085861649
@@ -3473,7 +3398,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 0922d514951db654c8f4026fe9e480f4, type: 3}
+  m_Sprite: {fileID: 21300000, guid: c4bef494bc09fb345b90199870dd29fc, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -5741,7 +5666,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 33.2, y: 8.8}
+  m_AnchoredPosition: {x: 665, y: 8.8}
   m_SizeDelta: {x: 90, y: 90}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1759715911
@@ -6443,7 +6368,6 @@ RectTransform:
   - {fileID: 1085861648}
   - {fileID: 591647597}
   - {fileID: 1759715910}
-  - {fileID: 345740093}
   m_Father: {fileID: 1540043244}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -6471,7 +6395,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: '  Join    Move    Confirm    Exit    Start When Ready'
+  m_text: '  Join/Ready    Move    Confirm    Exit '
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
   m_sharedMaterial: {fileID: -507269567956872517, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
@@ -6498,7 +6422,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 34.6
+  m_fontSize: 47
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -6734,19 +6658,16 @@ MonoBehaviour:
   - {fileID: 1085861649}
   - {fileID: 591647598}
   - {fileID: 1759715911}
-  - {fileID: 345740094}
   controllerInputPrompts:
-  - {fileID: 21300000, guid: 0922d514951db654c8f4026fe9e480f4, type: 3}
+  - {fileID: 21300000, guid: c4bef494bc09fb345b90199870dd29fc, type: 3}
   - {fileID: 21300000, guid: 271127115b8c8bf4f91941ffb5d20b78, type: 3}
   - {fileID: 21300000, guid: 8632def2730a1134ab4ce5975e9f3c03, type: 3}
   - {fileID: 21300000, guid: c47d2ec97e9dc6349bebfe36fefcd289, type: 3}
-  - {fileID: 21300000, guid: c4bef494bc09fb345b90199870dd29fc, type: 3}
   keyboardInputPrompts:
   - {fileID: 21300000, guid: e6dcd0c360eb1054b804f8beae7c723c, type: 3}
   - {fileID: 21300000, guid: e813208bbda015b4f95bffc4eaa85739, type: 3}
   - {fileID: 21300000, guid: 423e9f4a5e7f97b43b5241790845f302, type: 3}
   - {fileID: 21300000, guid: c8e3102adee278f43b68cb5d1e0657fb, type: 3}
-  - {fileID: 21300000, guid: e6dcd0c360eb1054b804f8beae7c723c, type: 3}
 --- !u!114 &2089025914
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
@@ -140,7 +140,7 @@ public class PlayerController : MonoBehaviour
         // The JoinScreen uses this event to launch the game if all players are ready
         if (currentState == ControllerState.JoinScreen)
         {
-            pjm.LaunchGameMode();
+            pjm.joinPanelContainer.transform.GetChild(Order).GetComponent<PlayerJoinPanel>().ReadyUp();
             return;
         }
         UIManager.PlayerPause(Order);

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
@@ -137,7 +137,7 @@ public class PlayerController : MonoBehaviour
     /// </summary>
     public void EmitPause()
     {
-        // The JoinScreen uses this event to launch the game if all players are ready
+        // The JoinScreen uses this event to ready up the player
         if (currentState == ControllerState.JoinScreen)
         {
             pjm.joinPanelContainer.transform.GetChild(Order).GetComponent<PlayerJoinPanel>().ReadyUp();

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
@@ -111,6 +111,18 @@ public class PlayerJoinManager : MonoBehaviour
     public void SetPlayerReady(int player, bool isReady)
     {
         joinStatus[player] = isReady;
+
+        foreach(KeyValuePair<int, bool> kvp in joinStatus)
+        {
+            if (!kvp.Value)
+            {
+                //Someone is not ready
+                return;
+            }
+        }
+
+        //Launch Game when everyone is ready
+        LaunchGameMode();
     }
 
     // This function launches the corresponding game mode that has been loaded by selection in the previous scene.
@@ -120,15 +132,6 @@ public class PlayerJoinManager : MonoBehaviour
         if (GameModeData.activeGameMode == EGameMode.Competitive && PlayerData.activePlayers.Count == 1)
         {
             return;
-        }
-
-        foreach(KeyValuePair<int, bool> kvp in joinStatus)
-        {
-            if (!kvp.Value)
-            {
-                //Someone is not ready
-                return;
-            }
         }
 
         if (!sceneTransition)

--- a/80s Game/Assets/Scripts/UI Scripts/PlayerJoinPanel.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/PlayerJoinPanel.cs
@@ -38,10 +38,11 @@ public class PlayerJoinPanel : MonoBehaviour
     private int initialThree = 65;
 
     //Variables for readying up
-    public Image readyIndicator;
-    public Sprite notReady;
-    public Sprite isReady;
+    public GameObject playerSettings;
+    public GameObject readyUpPrompt;
     public bool playerReady;
+    private GameObject lastSelected;
+    
 
     public EventSystem eventSystem;
     private int player;
@@ -64,9 +65,14 @@ public class PlayerJoinPanel : MonoBehaviour
         for (int i = 0; i < initials.Count; i++)
         {
             int iCopy = i;
-            initialUpButtons[i].onClick.AddListener(() => ChangeInitial(true, iCopy));
-            initialDownButtons[i].onClick.AddListener(() => ChangeInitial(false, iCopy));
+            initialUpButtons[i].onClick.AddListener(() => ChangeInitial(false, iCopy));
+            initialDownButtons[i].onClick.AddListener(() => ChangeInitial(true, iCopy));
         }
+
+        //Set preview crosshair to default color for that player
+        colorSliders[0].value = PlayerData.defaultColors[player].r * 255;
+        colorSliders[1].value = PlayerData.defaultColors[player].g * 255;
+        colorSliders[2].value = PlayerData.defaultColors[player].b * 255;
 
         //Turn off the corsshairs
         PauseScreenBehavior.Instance.ToggleCrosshairs(false);
@@ -156,12 +162,27 @@ public class PlayerJoinPanel : MonoBehaviour
         //Set the ready indicator to the appropriate sprite
         if (playerReady)
         {
-            readyIndicator.sprite = isReady;
+            readyUpPrompt.SetActive(true);
+            playerSettings.SetActive(false);
+
+
+            lastSelected = eventSystem.currentSelectedGameObject;
+
+            EventSystem.current.SetSelectedGameObject(null);
+            EventSystem.current.SetSelectedGameObject(readyUpPrompt.transform.GetChild(1).gameObject);
         }
         
         else
         {
-            readyIndicator.sprite = notReady;
+            readyUpPrompt.SetActive(false);
+            playerSettings.SetActive(true);
+
+            EventSystem.current.SetSelectedGameObject(null);
+
+            if (lastSelected != null)
+            {
+                EventSystem.current.SetSelectedGameObject(lastSelected);
+            }
         }
         pjm.SetPlayerReady(player, playerReady);
     }

--- a/80s Game/Assets/Scripts/UI Scripts/PlayerJoinPanel.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/PlayerJoinPanel.cs
@@ -159,12 +159,11 @@ public class PlayerJoinPanel : MonoBehaviour
         //Toggle whether the player is ready
         playerReady = !playerReady;
 
-        //Set the ready indicator to the appropriate sprite
+        //Show that the player is ready
         if (playerReady)
         {
             readyUpPrompt.SetActive(true);
             playerSettings.SetActive(false);
-
 
             lastSelected = eventSystem.currentSelectedGameObject;
 
@@ -172,6 +171,7 @@ public class PlayerJoinPanel : MonoBehaviour
             EventSystem.current.SetSelectedGameObject(readyUpPrompt.transform.GetChild(1).gameObject);
         }
         
+        //Show settings if player unreadies
         else
         {
             readyUpPrompt.SetActive(false);


### PR DESCRIPTION
## Summarize what is being added
-Default crosshair colors are now accurately displayed on the Join Screen
-Join Screen process has been readjusted to require less inputs
-Readying up now done by pressing Start/Space after joining (This reduces needing to navigate to a button or readying and then starting in Classic mode)
-Buttons for initials have had their behavior swapped based on feedback
-Prompt Tray on Join Screen has been updated to reflect new controls

## Please describe how to test
-Play the game and launch Classic mode, you should only have to press start when ready to launch into the loading screen
-Back out of the game and launch Competitive mode and join with at least two players
-Ready up with one player, the settings should disappear for a more explicit ready state (Press ready button again or cancel button to unready)
-Ready up with both players, the game should switch to the loading screen without requiring another input

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-154

## What Sprint is this due in?
Sprint 3