### PR TITLE
Reduce calls to database and constrain them to build only

### DIFF
--- a/80s Game/Assets/Scripts/GameManager.cs
+++ b/80s Game/Assets/Scripts/GameManager.cs
@@ -33,7 +33,6 @@ public class GameManager : MonoBehaviour
     public bool debug;
     private float gameStartTime;
     private List<PlayerController> players;
-    private bool isOnline;
 
     private void Awake()
     {
@@ -83,7 +82,6 @@ public class GameManager : MonoBehaviour
                     
                     players.Add(pc);
                 }
-                StartCoroutine(NetworkUtility.Ping(SetOnline));
             }
         }
     }
@@ -118,15 +116,6 @@ public class GameManager : MonoBehaviour
     {
         roundOverObservers?.Invoke();
         GameManager.Instance.PointsManager.ResetRoundPoints();
-    }
-
-    /// <summary>
-    /// Sets whether or not the client is connected to the internet
-    /// </summary>
-    /// <param name="value">The boolean that sets connectivity status</param>
-    private void SetOnline(bool value)
-    {
-        isOnline = value;
     }
 
     /// <summary>

--- a/80s Game/Assets/Scripts/GameModes/GameMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/GameMode.cs
@@ -1,3 +1,5 @@
+using UnityEngine;
+
 public enum EGameMode
 {
     Classic,
@@ -34,6 +36,15 @@ public abstract class AbsGameMode
 
     protected void EndGame()
     {
+        bool debug = Debug.isDebugBuild;
+#if UNITY_EDITOR
+        debug = true;
+#endif
+        if (debug)
+        {
+            return;
+        }
+
         GameManager.Instance.HandleGameOver();
     }
 

--- a/80s Game/Assets/Scripts/NetworkUtility.cs
+++ b/80s Game/Assets/Scripts/NetworkUtility.cs
@@ -1,34 +1,7 @@
 
-using System;
-using System.Collections;
-
-using UnityEngine.Networking;
-
 public static class NetworkUtility
 {
-
     // Currently pointing to localhost until we can set this up better
     public static string destinationURL = "https://35v53w7wwj.execute-api.us-east-1.amazonaws.com/default/SaveToMongo";
 
-    static UnityWebRequest req;
-
-    /// <summary>
-    /// Sends a request through the web to test connectivity to the server
-    /// </summary>
-    /// <param name="callback">A function that takes a boolean parameter</param>
-    /// <returns>A coroutine that will set whether this computer can connect to our server or not</returns>
-    public static IEnumerator Ping(Action<bool> callback)
-    {
-        req = new UnityWebRequest(destinationURL, "GET");
-        yield return req.SendWebRequest();
-
-        if (req.result == UnityWebRequest.Result.ConnectionError)
-        {
-            callback.Invoke(false);
-        }
-        else
-        {
-            callback.Invoke(true);
-        }
-    }
 }


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Reduce calls to the database so they only happen in the built version of the game.

This should reduce the impact of our debug efforts on the performance of our online systems.

## Please describe how to test
Try playing the game in-engine then check the database
No new entries should've been created.
Build the game - play it once.
New entries should have appeared in the database.

## Relevant Screenshots
Nothing to show

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?assignee=712020%3A72da91bd-2f5a-4c69-861e-59715da3052a&selectedIssue=BB-189

## What Sprint is this due in?
Sprint 3