### PR TITLE
Feature/limit data

### DIFF
--- a/80s Game/Assets/Scenes/TitleScreen.unity
+++ b/80s Game/Assets/Scenes/TitleScreen.unity
@@ -720,6 +720,7 @@ GameObject:
   - component: {fileID: 340111863}
   - component: {fileID: 340111864}
   - component: {fileID: 340111865}
+  - component: {fileID: 340111866}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -841,6 +842,18 @@ MonoBehaviour:
     y: 0
     width: 1
     height: 1
+--- !u!114 &340111866
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 340111859}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f5202112aa95d14a91404b0c3bc2471, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &363716640
 GameObject:
   m_ObjectHideFlags: 0

--- a/80s Game/Assets/Scripts/DataTracking/DataTracker.cs
+++ b/80s Game/Assets/Scripts/DataTracking/DataTracker.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using UnityEngine;
@@ -35,10 +36,14 @@ public abstract class DataSaver
 // Concrete data save class for interfacing with the local file system
 public class FileSystemDataSaver : DataSaver
 {
+    string filePath; 
+    public FileSystemDataSaver()
+    {
+        filePath = Application.dataPath + "/PlayerData/GameplayStats/";
+    }
     public override IEnumerator Save(SaveDataItem data)
     {
         // Establish a location where the data will be locally written to
-        string filePath = Application.dataPath + "/PlayerData/GameplayStats/";
         string fileName = Guid.NewGuid().ToString() + ".json";
         string dirPath = Path.GetDirectoryName(filePath + fileName);
         if (!Directory.Exists(dirPath))
@@ -49,6 +54,15 @@ public class FileSystemDataSaver : DataSaver
         // Write the data
         File.WriteAllText(filePath + fileName, JsonUtility.ToJson(data));
         yield return null;
+    }
+
+    public List<string> LoadData()
+    {
+        List<string> savedData = new List<string>();
+        string[] files = Directory.GetFiles(filePath, "*.json");
+        Debug.Log(files);
+        return savedData;
+
     }
 }
 

--- a/80s Game/Assets/Scripts/DataTracking/DataTracker.cs
+++ b/80s Game/Assets/Scripts/DataTracking/DataTracker.cs
@@ -42,7 +42,7 @@ public class FileSystemDataSaver : DataSaver
     public FileSystemDataSaver()
     {
         filePath = Application.dataPath + "/PlayerData/GameplayStats/";
-        fileLimitCount = 2;
+        fileLimitCount = 10;
     }
     public override IEnumerator Save(SaveDataItem data)
     {

--- a/80s Game/Assets/Scripts/DataTracking/DataTracker.cs
+++ b/80s Game/Assets/Scripts/DataTracking/DataTracker.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -36,10 +37,12 @@ public abstract class DataSaver
 // Concrete data save class for interfacing with the local file system
 public class FileSystemDataSaver : DataSaver
 {
-    string filePath; 
+    string filePath;
+    int fileLimitCount;
     public FileSystemDataSaver()
     {
         filePath = Application.dataPath + "/PlayerData/GameplayStats/";
+        fileLimitCount = 2;
     }
     public override IEnumerator Save(SaveDataItem data)
     {
@@ -53,17 +56,60 @@ public class FileSystemDataSaver : DataSaver
 
         // Write the data
         File.WriteAllText(filePath + fileName, JsonUtility.ToJson(data));
+        EliminateExcessFiles();
         yield return null;
     }
 
-    public List<string> LoadData()
-    {
-        List<string> savedData = new List<string>();
-        string[] files = Directory.GetFiles(filePath, "*.json");
-        Debug.Log(files);
-        return savedData;
 
+    /// <summary>
+    /// List all stored files of JSON game data
+    /// </summary>
+    /// <returns>A list of FileInfo objects</returns>
+    public List<FileInfo> GetDataFiles()
+    {
+        List<FileInfo> files = new DirectoryInfo(filePath).GetFiles("*.json").OrderByDescending(f => f.LastWriteTime).ToList();
+        return files;
     }
+
+
+    /// <summary>
+    /// Eliminate all stored data files that exceed maximum limit amounts and their 
+    /// associated meta files if they exist
+    /// </summary>
+    public void EliminateExcessFiles()
+    {
+        List<FileInfo> files = GetDataFiles();
+        for (int i = fileLimitCount + 1; i < files.Count; i++)
+        {
+            File.Delete(files[i].FullName);
+            if (File.Exists(files[i].FullName + ".meta"))
+            {
+                File.Delete(files[i].FullName + ".meta");
+            }   
+        }
+    }
+
+    /// <summary>
+    /// Eliminate file in data store and it's meta store, should one exist
+    /// </summary>
+    public void DeleteFile(string fileName)
+    {
+        File.Delete(fileName);
+        if (File.Exists(fileName + ".meta"))
+        {
+            File.Delete(fileName + ".meta");
+        }
+    }
+
+    /// <summary>
+    /// Read the contents of a file
+    /// </summary>
+    /// <param name="filePath"></param>
+    /// <returns>The string contents of a file</returns>
+    public string GetFileContents(string filePath)
+    {
+        return File.ReadAllText(filePath);
+    } 
 }
 
 
@@ -72,6 +118,14 @@ public class RemoteDataSaver : DataSaver
 {
     public override IEnumerator Save(SaveDataItem data)
     {
+        //Save files locally if this is a development environment
+        if (NetworkUtility.NetworkDevEnv())
+        {
+            FileSystemDataSaver saver = new FileSystemDataSaver();
+            yield return saver.Save(data);
+            yield break;
+        }
+
         // Prepare the request
         string url = NetworkUtility.destinationURL;
         UnityWebRequest request = new UnityWebRequest(url, UnityWebRequest.kHttpVerbPOST);
@@ -90,5 +144,30 @@ public class RemoteDataSaver : DataSaver
             FileSystemDataSaver saver = new FileSystemDataSaver();
             yield return saver.Save(data);
         }
+    }
+
+    /// <summary>
+    /// Syncs files to remote
+    /// </summary>
+    /// <param name="file">Index of the file to sync</param>
+    /// <param name="data">String of JSON-compliant data to send to the server</param>
+    /// <param name="callback">The function to call when the sync process is complete</param>
+    /// <returns>Nothing, this is a couroutine</returns>
+    public IEnumerator Sync(int file, string data, Action<int, bool> callback)
+    {
+        // Prepare the request
+        string url = NetworkUtility.destinationURL;
+        UnityWebRequest request = new UnityWebRequest(url, UnityWebRequest.kHttpVerbPOST);
+        request.SetRequestHeader("Content-Type", "application/json");
+        byte[] bodyRaw = Encoding.UTF8.GetBytes(data);
+        request.uploadHandler = new UploadHandlerRaw(bodyRaw);
+        request.downloadHandler = new DownloadHandlerBuffer();
+        
+        //Send the request
+        yield return request.SendWebRequest();
+        
+        // Fallback method in case our server becomes unreachable or the request fails
+        bool requestError = request.result != UnityWebRequest.Result.Success;
+        callback.Invoke(file, requestError);
     }
 }

--- a/80s Game/Assets/Scripts/DataTracking/FileSyncComponent.cs
+++ b/80s Game/Assets/Scripts/DataTracking/FileSyncComponent.cs
@@ -1,0 +1,77 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+public class FileSyncComponent : MonoBehaviour
+{
+    // Class to sync stored files to the remote data server
+    // If for whatever reason players can't sync their data to our server, it should get saved locally
+    // Then this class handles sending the local files to the remove server for storage
+    FileSystemDataSaver fileSystemInterface;
+    RemoteDataSaver remoteSystemInterface;
+    Dictionary<int, bool> syncStatus;
+    List<FileInfo> filenames;
+    private void Start()
+    {
+        // Escape out of this if we're in the debug environment
+        if (NetworkUtility.NetworkDevEnv())
+        {
+           return;
+        }
+
+        fileSystemInterface = new FileSystemDataSaver();
+        remoteSystemInterface = new RemoteDataSaver();
+        syncStatus = new Dictionary<int, bool>();
+        filenames =  fileSystemInterface.GetDataFiles();
+        if (filenames.Count > 0)
+        {
+            SyncFile(0, filenames[0].FullName);
+        }
+        
+    }
+
+    /// <summary>
+    /// Updates the dictionary that tracks progress on the status of the sync
+    /// Begins the process of deletion once all files have been processed
+    /// </summary>
+    /// <param name="index">The index of the file being updated</param>
+    /// <param name="value">The result of the update function</param>
+    private void UpdateSyncStatus(int index, bool value)
+    {
+        syncStatus.Add(index, value);
+        if (index < filenames.Count-1)
+        {
+            SyncFile(index + 1, filenames[index + 1].FullName);
+        } else
+        {
+            DeleteSyncedFiles();
+        }
+        
+    }
+
+
+    /// <summary>
+    /// Starts the coroutine that will save a file to remote.
+    /// Passes the UpdateSyncStatus as a callback to the coroutine to call when it's done
+    /// </summary>
+    /// <param name="index">The index of the file to sync</param>
+    /// <param name="filename">The name of the file to sync</param>
+    private void SyncFile(int index, string filename)
+    {
+        StartCoroutine(remoteSystemInterface.Sync(index, fileSystemInterface.GetFileContents(filename), UpdateSyncStatus));
+    }
+
+    /// <summary>
+    /// Delete all files that have been successfully synced.
+    /// Files that aren't synced remain in the host's machine to try syncing in the future.
+    /// These files might be deleted by the filesystem if they become too old and stale
+    /// </summary>
+    private void DeleteSyncedFiles()
+    {
+        foreach(KeyValuePair<int, bool> kvp in syncStatus)
+        {
+            if (kvp.Value) { fileSystemInterface.DeleteFile(filenames[kvp.Key].FullName); }
+        }
+    }
+}

--- a/80s Game/Assets/Scripts/DataTracking/FileSyncComponent.cs
+++ b/80s Game/Assets/Scripts/DataTracking/FileSyncComponent.cs
@@ -15,10 +15,10 @@ public class FileSyncComponent : MonoBehaviour
     private void Start()
     {
         // Escape out of this if we're in the debug environment
-        if (NetworkUtility.NetworkDevEnv())
+        /*if (NetworkUtility.NetworkDevEnv())
         {
            return;
-        }
+        }*/
 
         fileSystemInterface = new FileSystemDataSaver();
         remoteSystemInterface = new RemoteDataSaver();
@@ -37,9 +37,9 @@ public class FileSyncComponent : MonoBehaviour
     /// </summary>
     /// <param name="index">The index of the file being updated</param>
     /// <param name="value">The result of the update function</param>
-    private void UpdateSyncStatus(int index, bool value)
+    private void UpdateSyncStatus(int index, bool bIsError)
     {
-        syncStatus.Add(index, value);
+        syncStatus.Add(index, bIsError);
         if (index < filenames.Count-1)
         {
             SyncFile(index + 1, filenames[index + 1].FullName);
@@ -71,7 +71,7 @@ public class FileSyncComponent : MonoBehaviour
     {
         foreach(KeyValuePair<int, bool> kvp in syncStatus)
         {
-            if (kvp.Value) { fileSystemInterface.DeleteFile(filenames[kvp.Key].FullName); }
+            if (!kvp.Value) { fileSystemInterface.DeleteFile(filenames[kvp.Key].FullName); }
         }
     }
 }

--- a/80s Game/Assets/Scripts/DataTracking/FileSyncComponent.cs.meta
+++ b/80s Game/Assets/Scripts/DataTracking/FileSyncComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f5202112aa95d14a91404b0c3bc2471
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/80s Game/Assets/Scripts/GameModes/GameMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/GameMode.cs
@@ -36,15 +36,6 @@ public abstract class AbsGameMode
 
     protected void EndGame()
     {
-        bool debug = Debug.isDebugBuild;
-#if UNITY_EDITOR
-        debug = true;
-#endif
-        if (debug)
-        {
-            return;
-        }
-
         GameManager.Instance.HandleGameOver();
     }
 

--- a/80s Game/Assets/Scripts/NetworkUtility.cs
+++ b/80s Game/Assets/Scripts/NetworkUtility.cs
@@ -1,7 +1,20 @@
-
+using UnityEngine;
 public static class NetworkUtility
 {
     // Currently pointing to localhost until we can set this up better
     public static string destinationURL = "https://35v53w7wwj.execute-api.us-east-1.amazonaws.com/default/SaveToMongo";
 
+    /// <summary>
+    /// Function that checks whether or not this environment should be sending data remotely
+    /// Development environments do not send data to remote
+    /// </summary>
+    /// <returns>Returns true if this is a development environment</returns>
+    public static bool NetworkDevEnv()
+    {
+        bool debug = Debug.isDebugBuild;
+#if UNITY_EDITOR
+        debug = true;
+#endif
+        return debug;
+    }
 }


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Created a system to limit the amount of storage taken up by our data tracking files in a user's machine.
Also implemented the sync system to get that data out at the start of a play session.

## Please describe how to test
Play some games, it should create some files in your local machine (look in ./Assets/PlayerData/GameplayStats).
Change line 45 of the FileSystemDataSaver to save 1 or 2 files.
Play another game. Previous data should be destroyed and only the most recent files should remain.
Stop playing.

Make a backup of the files that remain in GameplayStats in another folder.
Comment out lies 18-21 of the DataTracking/FileSyncComponent.cs script.
Start the game.
Your local save data files should be gone.
Check the database and contrast the backup with the most recently inserted files.
Information in them should match.

## Relevant Screenshots
The new file sync component in the GameManager in the title screen
![image](https://github.com/mythguy1226/80sgame/assets/9394777/d22c2d78-617d-420d-9969-0f32765a223d)


## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?assignee=712020%3A72da91bd-2f5a-4c69-861e-59715da3052a&selectedIssue=BB-163

## What Sprint is this due in?
Sprint 3