### PR TITLE
Color Preset Bugfixes

### DIFF
--- a/80s Game/Assets/Scenes/JoinScene.unity
+++ b/80s Game/Assets/Scenes/JoinScene.unity
@@ -809,12 +809,12 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 668303352}
-  m_Father: {fileID: 1540043244}
+  m_Father: {fileID: 1990815587}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -22.000002, y: 468.00003}
+  m_SizeDelta: {x: 85.45007, y: 1032.64}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &415838846
 MonoBehaviour:
@@ -2074,7 +2074,6 @@ RectTransform:
   - {fileID: 1597708972}
   - {fileID: 745268982}
   - {fileID: 1990815587}
-  - {fileID: 415838845}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -3070,6 +3069,7 @@ RectTransform:
   - {fileID: 1085861648}
   - {fileID: 591647597}
   - {fileID: 1759715910}
+  - {fileID: 415838845}
   m_Father: {fileID: 1540043244}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
@@ -97,6 +97,27 @@ public class PlayerJoinManager : MonoBehaviour
                 }
             }
         }
+
+        //Set color preset based on default color
+        switch(pc.Order)
+        {
+            case 1: 
+                newPlayerPanel.GetComponent<PlayerJoinPanel>().colorDropdown.value = 1;
+                break;
+            case 2: 
+                newPlayerPanel.GetComponent<PlayerJoinPanel>().colorDropdown.value = 2;
+                break;
+            case 3: 
+                newPlayerPanel.GetComponent<PlayerJoinPanel>().colorDropdown.value = 5;
+                break;
+        }
+
+        //Disable auto scroll for color preset dropdown if using mouse and keyboard
+        if (playerInput.currentControlScheme == "KnM")
+        {
+            newPlayerPanel.GetComponent<PlayerJoinPanel>().colorDropdown.gameObject.transform.GetChild(2).GetComponent<ScrollRectEnsureVisible>().enabled = false;
+        }
+
         //joinPrompt.text = "Press Start when ready";
         //joinPrompt.rectTransform.SetLocalPositionAndRotation(new Vector3(0, -460, 0), Quaternion.identity);
 

--- a/80s Game/Assets/Scripts/UI Scripts/PlayerJoinPanel.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/PlayerJoinPanel.cs
@@ -148,6 +148,12 @@ public class PlayerJoinPanel : MonoBehaviour
             colorSliders[2].value = newColor.b * 255;
         }
 
+        //Fix Green slider being set to 128 when using Green preset
+        if (colorDropdown.captionText.text == "Green")
+        {
+            colorSliders[1].value *= 2;
+        }
+
         //Change the crosshair color based off of the new slider values
         ChangeCrosshairColor();
         UpdatePlayerConfig();


### PR DESCRIPTION
## Summarize what is being added
-Color presets are now accurately set to the default crosshair colors on the Join Screen
-Green color preset is now set to 255 instead of 128 for the Green value
-Color Preset dropdown no longer breaks when hovering with mouse (navigating with WASD will not scroll however)

## Please describe how to test
-Load up the Join Screen with competitive mode selected and join with at least 2 players (4 if possible)
-Open the color settings, each preset should have the appropriate color selected for each crosshair (i.e. the red crosshair should have the red preset selected)
-Select green with one of the crosshairs, it should now set the color to (0, 255, 0)
-Navigate the color preset dropdown with the mouse, it should function as expected

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-190

## What Sprint is this due in?
Sprint 3