### PR TITLE
Game now checks GameStats existence before attempting to read

### DIFF
--- a/80s Game/Assets/Scripts/DataTracking/DataTracker.cs
+++ b/80s Game/Assets/Scripts/DataTracking/DataTracker.cs
@@ -67,6 +67,11 @@ public class FileSystemDataSaver : DataSaver
     /// <returns>A list of FileInfo objects</returns>
     public List<FileInfo> GetDataFiles()
     {
+        string dirPath = Path.GetDirectoryName(filePath);
+        if (!Directory.Exists(dirPath))
+        {
+            Directory.CreateDirectory(dirPath);
+        }
         List<FileInfo> files = new DirectoryInfo(filePath).GetFiles("*.json").OrderByDescending(f => f.LastWriteTime).ToList();
         return files;
     }

--- a/80s Game/Assets/Scripts/DataTracking/FileSyncComponent.cs
+++ b/80s Game/Assets/Scripts/DataTracking/FileSyncComponent.cs
@@ -15,10 +15,10 @@ public class FileSyncComponent : MonoBehaviour
     private void Start()
     {
         // Escape out of this if we're in the debug environment
-        /*if (NetworkUtility.NetworkDevEnv())
+        if (NetworkUtility.NetworkDevEnv())
         {
            return;
-        }*/
+        }
 
         fileSystemInterface = new FileSystemDataSaver();
         remoteSystemInterface = new RemoteDataSaver();


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Game was coming into an error because it wasn't checking for the existence of the GameStats local file before attempting to read from it.

## Please describe how to test
Delete the local GameStats folder
Play the game. No problems should arise.

## Relevant Screenshots
![image](https://github.com/mythguy1226/80sgame/assets/9394777/077b3288-db11-418a-b7dc-cbd26c515a09)


## Issue worked on
No issue created

## What Sprint is this due in?
Sprint 3