### PR TITLE
separate controller input mapping

### DIFF
--- a/80s Game/Assets/PlayerInput/InputActions.inputactions
+++ b/80s Game/Assets/PlayerInput/InputActions.inputactions
@@ -94,7 +94,7 @@
                     "path": "<Gamepad>/leftStick",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4",
+                    "groups": "PS4;xbox",
                     "action": "Move",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -171,7 +171,7 @@
                     "path": "<Gamepad>/rightTrigger",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4",
+                    "groups": "PS4;xbox",
                     "action": "Fire",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -193,7 +193,7 @@
                     "path": "<Gamepad>/start",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4",
+                    "groups": "PS4;xbox",
                     "action": "Pause",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -215,7 +215,7 @@
                     "path": "<Gamepad>/buttonSouth",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4",
+                    "groups": "PS4;xbox",
                     "action": "Recenter",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -226,7 +226,7 @@
                     "path": "<Gamepad>/buttonEast",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4;Xbox",
+                    "groups": "PS4;Xbox;xbox",
                     "action": "Cancel",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -237,7 +237,7 @@
                     "path": "<Gamepad>/rightShoulder",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4",
+                    "groups": "PS4;xbox",
                     "action": "NextTab",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -259,7 +259,7 @@
                     "path": "<Gamepad>/leftShoulder",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4",
+                    "groups": "PS4;xbox",
                     "action": "PreviousTab",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -292,7 +292,7 @@
                     "path": "<Gamepad>/start",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4",
+                    "groups": "PS4;xbox",
                     "action": "Join",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -891,7 +891,18 @@
             "bindingGroup": "PS4",
             "devices": [
                 {
-                    "devicePath": "<Gamepad>",
+                    "devicePath": "<DualShockGamepad>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        },
+        {
+            "name": "xbox",
+            "bindingGroup": "xbox",
+            "devices": [
+                {
+                    "devicePath": "<XInputController>",
                     "isOptional": false,
                     "isOR": false
                 }

--- a/80s Game/Assets/PlayerInput/InputActions.inputactions
+++ b/80s Game/Assets/PlayerInput/InputActions.inputactions
@@ -443,7 +443,7 @@
                     "path": "<Gamepad>/leftStick/up",
                     "interactions": "",
                     "processors": "",
-                    "groups": "Gamepad;PS4",
+                    "groups": "Gamepad;PS4;xbox",
                     "action": "Navigate",
                     "isComposite": false,
                     "isPartOfComposite": true
@@ -454,7 +454,7 @@
                     "path": "<Gamepad>/rightStick/up",
                     "interactions": "",
                     "processors": "",
-                    "groups": "Gamepad;PS4",
+                    "groups": "Gamepad;PS4;xbox",
                     "action": "Navigate",
                     "isComposite": false,
                     "isPartOfComposite": true
@@ -465,7 +465,7 @@
                     "path": "<Gamepad>/leftStick/down",
                     "interactions": "",
                     "processors": "",
-                    "groups": "Gamepad;PS4",
+                    "groups": "Gamepad;PS4;xbox",
                     "action": "Navigate",
                     "isComposite": false,
                     "isPartOfComposite": true
@@ -476,7 +476,7 @@
                     "path": "<Gamepad>/rightStick/down",
                     "interactions": "",
                     "processors": "",
-                    "groups": "Gamepad;PS4",
+                    "groups": "Gamepad;PS4;xbox",
                     "action": "Navigate",
                     "isComposite": false,
                     "isPartOfComposite": true
@@ -487,7 +487,7 @@
                     "path": "<Gamepad>/leftStick/left",
                     "interactions": "",
                     "processors": "",
-                    "groups": "Gamepad;PS4",
+                    "groups": "Gamepad;PS4;xbox",
                     "action": "Navigate",
                     "isComposite": false,
                     "isPartOfComposite": true
@@ -498,7 +498,7 @@
                     "path": "<Gamepad>/rightStick/left",
                     "interactions": "",
                     "processors": "",
-                    "groups": "Gamepad;PS4",
+                    "groups": "Gamepad;PS4;xbox",
                     "action": "Navigate",
                     "isComposite": false,
                     "isPartOfComposite": true
@@ -509,7 +509,7 @@
                     "path": "<Gamepad>/leftStick/right",
                     "interactions": "",
                     "processors": "",
-                    "groups": "Gamepad;PS4",
+                    "groups": "Gamepad;PS4;xbox",
                     "action": "Navigate",
                     "isComposite": false,
                     "isPartOfComposite": true
@@ -520,7 +520,7 @@
                     "path": "<Gamepad>/rightStick/right",
                     "interactions": "",
                     "processors": "",
-                    "groups": "Gamepad;PS4",
+                    "groups": "Gamepad;PS4;xbox",
                     "action": "Navigate",
                     "isComposite": false,
                     "isPartOfComposite": true
@@ -531,7 +531,7 @@
                     "path": "<Gamepad>/dpad",
                     "interactions": "",
                     "processors": "",
-                    "groups": "Gamepad;PS4",
+                    "groups": "Gamepad;PS4;xbox",
                     "action": "Navigate",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -696,7 +696,7 @@
                     "path": "*/{Submit}",
                     "interactions": "",
                     "processors": "",
-                    "groups": "Keyboard&Mouse;Gamepad;Touch;Joystick;XR;KnM;PS4",
+                    "groups": "Keyboard&Mouse;Gamepad;Touch;Joystick;XR;KnM;PS4;xbox",
                     "action": "Submit",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -707,7 +707,7 @@
                     "path": "*/{Cancel}",
                     "interactions": "",
                     "processors": "",
-                    "groups": "Keyboard&Mouse;Gamepad;Touch;Joystick;XR;KnM;PS4",
+                    "groups": "Keyboard&Mouse;Gamepad;Touch;Joystick;XR;KnM;PS4;xbox",
                     "action": "Cancel",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -850,7 +850,7 @@
                     "path": "<Gamepad>/start",
                     "interactions": "",
                     "processors": "",
-                    "groups": "PS4",
+                    "groups": "PS4;xbox",
                     "action": "StartGame",
                     "isComposite": false,
                     "isPartOfComposite": false


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Creates a new input mapping for Xbox controllers that is separate from ps4

## Please describe how to test
Someone with an Xbox controller needs to play the game to make sure things work as expected

## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->

## Issue worked on
No issue

## What Sprint is this due in?
Sprint 4