### PR TITLE
Playstation Input Prompts

### DIFF
--- a/80s Game/Assets/Prefabs/Settings Panel.prefab
+++ b/80s Game/Assets/Prefabs/Settings Panel.prefab
@@ -8683,7 +8683,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -771, y: 321.22}
+  m_AnchoredPosition: {x: -765, y: 326}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &313383103083206417
@@ -8714,7 +8714,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 51cb69bf594c65049b4f8754de7e67db, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 06d718ce91157f54c8d7ea5dc3e6e63b, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -10353,7 +10353,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 830.97, y: 321.22}
+  m_AnchoredPosition: {x: 823, y: 326}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5213263697523488159
@@ -10384,7 +10384,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: ba243ab6d8ab3aa4489be7e8b7044303, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 2e53c3a4923ec234fb51a4433c3781c8, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/80s Game/Assets/Scenes/CompetitiveMode.unity
+++ b/80s Game/Assets/Scenes/CompetitiveMode.unity
@@ -2385,6 +2385,28 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 349391994}
   m_CullTransparentMesh: 1
+--- !u!114 &356011485 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 650512168210861314, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+  m_PrefabInstance: {fileID: 1093280405}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &356011486 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4184649026959582423, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+  m_PrefabInstance: {fileID: 1093280405}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &367589952
 GameObject:
   m_ObjectHideFlags: 0
@@ -7303,7 +7325,8 @@ MonoBehaviour:
   onboardingPanel: {fileID: 272465747}
   gameUIElements: {fileID: 1759806105}
   mouseDiagram: {fileID: 2133569414}
-  controllerDiagram: {fileID: 2011530929}
+  xboxControllerDiagram: {fileID: 2011530929}
+  playstationControllerDiagram: {fileID: 1792028612}
   gameStartTheme: {fileID: 8300000, guid: e942b01d049936e498911c35cd71e6c8, type: 3}
 --- !u!114 &1011990665
 MonoBehaviour:
@@ -7353,6 +7376,8 @@ MonoBehaviour:
   - {fileID: 1275475504}
   - {fileID: 1663570781}
   - {fileID: 1728095437}
+  controllerPauseInputs: []
+  pauseInputPrompt: {fileID: 0}
   coreHealthbar: {fileID: 0}
   coreHealthPercentage: {fileID: 0}
   core: {fileID: 0}
@@ -7390,6 +7415,16 @@ MonoBehaviour:
   tabs:
   - {fileID: 1128652027}
   - {fileID: 1128652026}
+  tabPrompts:
+  - {fileID: 356011486}
+  - {fileID: 356011485}
+  controllerTabPrompts:
+  - {fileID: 21300000, guid: 6f9a107ee5659df488c5d702dea176e0, type: 3}
+  - {fileID: 21300000, guid: 46ae969a0ae51eb4c8385b6b8d6aad1f, type: 3}
+  - {fileID: 21300000, guid: 51cb69bf594c65049b4f8754de7e67db, type: 3}
+  - {fileID: 21300000, guid: ba243ab6d8ab3aa4489be7e8b7044303, type: 3}
+  - {fileID: 21300000, guid: 06d718ce91157f54c8d7ea5dc3e6e63b, type: 3}
+  - {fileID: 21300000, guid: 2e53c3a4923ec234fb51a4433c3781c8, type: 3}
   controlMappings:
   - {fileID: 1128652025}
   - {fileID: 1128652024}
@@ -7518,8 +7553,20 @@ PrefabInstance:
       value: CancelSettings
       objectReference: {fileID: 0}
     - target: {fileID: 1652444051340644412, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1652444051340644412, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1652444051340644412, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 303.28003
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1652444051340644412, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1866027868665589085, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -7562,8 +7609,20 @@ PrefabInstance:
       value: ChangeSensitivity
       objectReference: {fileID: 0}
     - target: {fileID: 2327607288610509116, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2327607288610509116, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2327607288610509116, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 303.28003
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2327607288610509116, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2411005472448371026, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_Pivot.x
@@ -7653,6 +7712,30 @@ PrefabInstance:
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: ChangeCRTCurvature
       objectReference: {fileID: 0}
+    - target: {fileID: 2981887493241553438, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2981887493241553438, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2981887493241553438, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3097753170795318919, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3097753170795318919, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3097753170795318919, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3857794041588434869, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
@@ -7710,12 +7793,44 @@ PrefabInstance:
       value: ApplySettings
       objectReference: {fileID: 0}
     - target: {fileID: 4595563836386087559, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595563836386087559, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595563836386087559, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 303.28003
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595563836386087559, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5372137882276417463, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5372137882276417463, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569311816751516274, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569311816751516274, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5569311816751516274, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 303.28003
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569311816751516274, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5694144902731231069, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -7725,13 +7840,29 @@ PrefabInstance:
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: ChangeMusicVolume
       objectReference: {fileID: 0}
+    - target: {fileID: 6285397930073642775, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6388397268345708563, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_Name
       value: Settings Panel
       objectReference: {fileID: 0}
     - target: {fileID: 6879027392704449552, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6879027392704449552, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6879027392704449552, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 303.28003
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6879027392704449552, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7065630099877724406, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -7742,8 +7873,20 @@ PrefabInstance:
       value: ToggleSettingsPanel
       objectReference: {fileID: 0}
     - target: {fileID: 8030518974427849635, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8030518974427849635, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8030518974427849635, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 303.28003
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8030518974427849635, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8541937061869130699, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target

--- a/80s Game/Assets/Scenes/CooperativeMode.unity
+++ b/80s Game/Assets/Scenes/CooperativeMode.unity
@@ -7181,7 +7181,8 @@ MonoBehaviour:
   onboardingPanel: {fileID: 1438820510}
   gameUIElements: {fileID: 1759806105}
   mouseDiagram: {fileID: 1965499565}
-  controllerDiagram: {fileID: 181718769}
+  xboxControllerDiagram: {fileID: 181718769}
+  playstationControllerDiagram: {fileID: 459211031}
   gameStartTheme: {fileID: 8300000, guid: e942b01d049936e498911c35cd71e6c8, type: 3}
 --- !u!114 &1011990665
 MonoBehaviour:
@@ -7231,6 +7232,8 @@ MonoBehaviour:
   - {fileID: 949358370}
   - {fileID: 1750415205}
   - {fileID: 2088532728}
+  controllerPauseInputs: []
+  pauseInputPrompt: {fileID: 0}
   coreHealthbar: {fileID: 1287514253}
   coreHealthPercentage: {fileID: 1585191500}
   core: {fileID: 1121493176}
@@ -7268,6 +7271,16 @@ MonoBehaviour:
   tabs:
   - {fileID: 1128652027}
   - {fileID: 1128652026}
+  tabPrompts:
+  - {fileID: 1628310490}
+  - {fileID: 1628310489}
+  controllerTabPrompts:
+  - {fileID: 21300000, guid: 6f9a107ee5659df488c5d702dea176e0, type: 3}
+  - {fileID: 21300000, guid: 46ae969a0ae51eb4c8385b6b8d6aad1f, type: 3}
+  - {fileID: 21300000, guid: 51cb69bf594c65049b4f8754de7e67db, type: 3}
+  - {fileID: 21300000, guid: ba243ab6d8ab3aa4489be7e8b7044303, type: 3}
+  - {fileID: 21300000, guid: 06d718ce91157f54c8d7ea5dc3e6e63b, type: 3}
+  - {fileID: 21300000, guid: 2e53c3a4923ec234fb51a4433c3781c8, type: 3}
   controlMappings:
   - {fileID: 1128652025}
   - {fileID: 1128652024}
@@ -7572,8 +7585,20 @@ PrefabInstance:
       value: CancelSettings
       objectReference: {fileID: 0}
     - target: {fileID: 1652444051340644412, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1652444051340644412, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1652444051340644412, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 303.28003
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1652444051340644412, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1866027868665589085, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: onValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -7616,8 +7641,20 @@ PrefabInstance:
       value: ChangeSensitivity
       objectReference: {fileID: 0}
     - target: {fileID: 2327607288610509116, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2327607288610509116, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2327607288610509116, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 303.28003
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2327607288610509116, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2411005472448371026, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_Pivot.x
@@ -7707,6 +7744,30 @@ PrefabInstance:
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: ChangeCRTCurvature
       objectReference: {fileID: 0}
+    - target: {fileID: 2981887493241553438, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2981887493241553438, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2981887493241553438, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3097753170795318919, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3097753170795318919, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3097753170795318919, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3857794041588434869, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
@@ -7756,12 +7817,44 @@ PrefabInstance:
       value: ApplySettings
       objectReference: {fileID: 0}
     - target: {fileID: 4595563836386087559, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595563836386087559, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595563836386087559, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 303.28003
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4595563836386087559, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5372137882276417463, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5372137882276417463, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569311816751516274, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569311816751516274, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5569311816751516274, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 303.28003
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569311816751516274, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5694144902731231069, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -7771,13 +7864,29 @@ PrefabInstance:
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: ChangeMusicVolume
       objectReference: {fileID: 0}
+    - target: {fileID: 6285397930073642775, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6388397268345708563, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_Name
       value: Settings Panel
       objectReference: {fileID: 0}
     - target: {fileID: 6879027392704449552, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6879027392704449552, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6879027392704449552, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 303.28003
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6879027392704449552, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7065630099877724406, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -7788,8 +7897,20 @@ PrefabInstance:
       value: ToggleSettingsPanel
       objectReference: {fileID: 0}
     - target: {fileID: 8030518974427849635, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8030518974427849635, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8030518974427849635, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 303.28003
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8030518974427849635, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8541937061869130699, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -12412,6 +12533,28 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e0d36a1c5204198468bfd77d36f33315, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1628310489 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 650512168210861314, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+  m_PrefabInstance: {fileID: 1093280405}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1628310490 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4184649026959582423, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+  m_PrefabInstance: {fileID: 1093280405}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1637678390

--- a/80s Game/Assets/Scenes/JoinScene.unity
+++ b/80s Game/Assets/Scenes/JoinScene.unity
@@ -728,6 +728,81 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 141723223}
   m_CullTransparentMesh: 1
+--- !u!1 &355847416
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 355847417}
+  - component: {fileID: 355847419}
+  - component: {fileID: 355847418}
+  m_Layer: 5
+  m_Name: Fire Input (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &355847417
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 355847416}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1978148771}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 209, y: -63.665}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &355847418
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 355847416}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: e6dcd0c360eb1054b804f8beae7c723c, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &355847419
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 355847416}
+  m_CullTransparentMesh: 1
 --- !u!1 &370928175
 GameObject:
   m_ObjectHideFlags: 0
@@ -1534,7 +1609,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 103, y: -63.665}
+  m_AnchoredPosition: {x: -1, y: -63.665}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1134723289
@@ -1557,7 +1632,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: e6dcd0c360eb1054b804f8beae7c723c, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 2fa78ecfaa23c6a41bdc963c0cf10c85, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1609,7 +1684,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -112, y: -63.665}
+  m_AnchoredPosition: {x: -225, y: -63.665}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1157683685
@@ -1744,6 +1819,7 @@ MonoBehaviour:
   roundEndTheme: {fileID: 0}
   gameModeType: 3
   isSlowed: 0
+  rustedWingsStack: 0
   debuffActive: 0
   buffs: []
   debuffs: []
@@ -2931,6 +3007,7 @@ RectTransform:
   m_Children:
   - {fileID: 1157683684}
   - {fileID: 1134723288}
+  - {fileID: 355847417}
   m_Father: {fileID: 1540043244}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -2958,7 +3035,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: "Press Start To Join\n\n(  /  ) \n"
+  m_text: "Press Start To Join\n\n(  /  /  ) \n"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
   m_sharedMaterial: {fileID: -507269567956872517, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
@@ -3285,7 +3362,12 @@ MonoBehaviour:
   - {fileID: 1085861649}
   - {fileID: 591647598}
   - {fileID: 1759715911}
-  controllerInputPrompts:
+  playstationInputPrompts:
+  - {fileID: 21300000, guid: 2fa78ecfaa23c6a41bdc963c0cf10c85, type: 3}
+  - {fileID: 21300000, guid: 3165452b65290ef48abf6a05012bcc55, type: 3}
+  - {fileID: 21300000, guid: b5db021c1b8911c46b3dba91d5039dc4, type: 3}
+  - {fileID: 21300000, guid: cbfb4e55520940b4c87e1a818abaf973, type: 3}
+  xboxInputPrompts:
   - {fileID: 21300000, guid: c4bef494bc09fb345b90199870dd29fc, type: 3}
   - {fileID: 21300000, guid: 271127115b8c8bf4f91941ffb5d20b78, type: 3}
   - {fileID: 21300000, guid: 8632def2730a1134ab4ce5975e9f3c03, type: 3}

--- a/80s Game/Assets/Scenes/SampleScene.unity
+++ b/80s Game/Assets/Scenes/SampleScene.unity
@@ -1138,6 +1138,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: LookingGlass
       objectReference: {fileID: 0}
+    - target: {fileID: 1035576977932210131, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -1479,6 +1483,81 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 299158705}
+  m_CullTransparentMesh: 1
+--- !u!1 &359227765
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 359227766}
+  - component: {fileID: 359227768}
+  - component: {fileID: 359227767}
+  m_Layer: 5
+  m_Name: Pause Input Prompt
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &359227766
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 359227765}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1978689094}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 181.3, y: 4}
+  m_SizeDelta: {x: 80, y: 80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &359227767
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 359227765}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: c8e3102adee278f43b68cb5d1e0657fb, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &359227768
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 359227765}
   m_CullTransparentMesh: 1
 --- !u!1 &367589952
 GameObject:
@@ -6658,7 +6737,8 @@ MonoBehaviour:
   onboardingPanel: {fileID: 1561009852}
   gameUIElements: {fileID: 1759806105}
   mouseDiagram: {fileID: 275948030}
-  controllerDiagram: {fileID: 519723845}
+  xboxControllerDiagram: {fileID: 519723845}
+  playstationControllerDiagram: {fileID: 1388510295}
   gameStartTheme: {fileID: 8300000, guid: e942b01d049936e498911c35cd71e6c8, type: 3}
 --- !u!114 &1011990665
 MonoBehaviour:
@@ -6707,6 +6787,10 @@ MonoBehaviour:
   roundIndicatorTextObject: {fileID: 736886330}
   bottomScoreTextObject: {fileID: 225425479}
   playerNames: []
+  controllerPauseInputs:
+  - {fileID: 21300000, guid: 2fa78ecfaa23c6a41bdc963c0cf10c85, type: 3}
+  - {fileID: 21300000, guid: c4bef494bc09fb345b90199870dd29fc, type: 3}
+  pauseInputPrompt: {fileID: 359227767}
   coreHealthbar: {fileID: 0}
   coreHealthPercentage: {fileID: 0}
   core: {fileID: 0}
@@ -6744,6 +6828,16 @@ MonoBehaviour:
   tabs:
   - {fileID: 866055502}
   - {fileID: 866055501}
+  tabPrompts:
+  - {fileID: 1210705294}
+  - {fileID: 1210705293}
+  controllerTabPrompts:
+  - {fileID: 21300000, guid: 6f9a107ee5659df488c5d702dea176e0, type: 3}
+  - {fileID: 21300000, guid: 46ae969a0ae51eb4c8385b6b8d6aad1f, type: 3}
+  - {fileID: 21300000, guid: 51cb69bf594c65049b4f8754de7e67db, type: 3}
+  - {fileID: 21300000, guid: ba243ab6d8ab3aa4489be7e8b7044303, type: 3}
+  - {fileID: 21300000, guid: 06d718ce91157f54c8d7ea5dc3e6e63b, type: 3}
+  - {fileID: 21300000, guid: 2e53c3a4923ec234fb51a4433c3781c8, type: 3}
   controlMappings:
   - {fileID: 866055500}
   - {fileID: 866055499}
@@ -7893,6 +7987,28 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1191442807}
   m_CullTransparentMesh: 1
+--- !u!114 &1210705293 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 650512168210861314, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+  m_PrefabInstance: {fileID: 1820304737}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1210705294 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4184649026959582423, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+  m_PrefabInstance: {fileID: 1820304737}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1231367926
 GameObject:
   m_ObjectHideFlags: 0
@@ -10663,6 +10779,22 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1011990667}
+    - target: {fileID: 8030518974427849635, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8030518974427849635, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8030518974427849635, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8030518974427849635, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8541937061869130699, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
@@ -11804,13 +11936,14 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 359227766}
   m_Father: {fileID: 1759806106}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 736, y: -508}
-  m_SizeDelta: {x: 584.2868, y: 64.4583}
+  m_AnchoredPosition: {x: 701.2, y: -484.1}
+  m_SizeDelta: {x: 549.52, y: 64.46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1978689095
 MonoBehaviour:
@@ -11832,7 +11965,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: (+/-) Pause
+  m_text: ' Pause:'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
   m_sharedMaterial: {fileID: -507269567956872517, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
@@ -11859,15 +11992,15 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 35.69
-  m_fontSizeBase: 35.69
+  m_fontSize: 42.04
+  m_fontSizeBase: 42.04
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0

--- a/80s Game/Assets/Scenes/TitleScreen.unity
+++ b/80s Game/Assets/Scenes/TitleScreen.unity
@@ -631,6 +631,10 @@ MonoBehaviour:
   - {fileID: 825267117}
   - {fileID: 1052698252}
   - {fileID: 1301689758}
+  helpInputPrompt: {fileID: 1029659480}
+  controllerHelpInputs:
+  - {fileID: 21300000, guid: 2fa78ecfaa23c6a41bdc963c0cf10c85, type: 3}
+  - {fileID: 21300000, guid: c4bef494bc09fb345b90199870dd29fc, type: 3}
 --- !u!114 &319221313
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -686,6 +690,16 @@ MonoBehaviour:
   tabs:
   - {fileID: 339623330}
   - {fileID: 707411550}
+  tabPrompts:
+  - {fileID: 1867834258203497353}
+  - {fileID: 1867834258203497352}
+  controllerTabPrompts:
+  - {fileID: 21300000, guid: 6f9a107ee5659df488c5d702dea176e0, type: 3}
+  - {fileID: 21300000, guid: 46ae969a0ae51eb4c8385b6b8d6aad1f, type: 3}
+  - {fileID: 21300000, guid: 51cb69bf594c65049b4f8754de7e67db, type: 3}
+  - {fileID: 21300000, guid: ba243ab6d8ab3aa4489be7e8b7044303, type: 3}
+  - {fileID: 21300000, guid: 06d718ce91157f54c8d7ea5dc3e6e63b, type: 3}
+  - {fileID: 21300000, guid: 2e53c3a4923ec234fb51a4433c3781c8, type: 3}
   controlMappings:
   - {fileID: 154591517}
   - {fileID: 1333690338}
@@ -2165,7 +2179,7 @@ GameObject:
   - component: {fileID: 1029659481}
   - component: {fileID: 1029659480}
   m_Layer: 5
-  m_Name: Image
+  m_Name: Help Input Prompt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2210,7 +2224,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: c4bef494bc09fb345b90199870dd29fc, type: 3}
+  m_Sprite: {fileID: 21300000, guid: c8e3102adee278f43b68cb5d1e0657fb, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -4542,6 +4556,28 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1867834258203497352 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 650512168210861314, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+  m_PrefabInstance: {fileID: 1867834258203497347}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1867834258203497353 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4184649026959582423, guid: ade02431274cdbe4f8fd5b4bdc90b6b9, type: 3}
+  m_PrefabInstance: {fileID: 1867834258203497347}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &4229236438130621606

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
@@ -24,7 +24,8 @@ public class PlayerJoinManager : MonoBehaviour
     public Sprite defenseBG;
 
     public List<Image> promptTrayIcons;
-    public List<Sprite> controllerInputPrompts;
+    public List<Sprite> playstationInputPrompts;
+    public List<Sprite> xboxInputPrompts;
     public List<Sprite> keyboardInputPrompts;
 
     private GameObject lastSelected = null;
@@ -98,14 +99,23 @@ public class PlayerJoinManager : MonoBehaviour
                 }
             }
 
-            else
+            else if (playerInput.currentControlScheme == "PS4")
             {
                 for (int i = 0; i < promptTrayIcons.Count; i++)
                 {
-                    promptTrayIcons[i].sprite = controllerInputPrompts[i];
+                    promptTrayIcons[i].sprite = playstationInputPrompts[i];
                     controllerConnected = true;
                 }
             }
+
+            else if (playerInput.currentControlScheme == "xbox")
+            {
+                for (int i = 0; i < promptTrayIcons.Count; i++)
+                {
+                    promptTrayIcons[i].sprite = xboxInputPrompts[i];
+                    controllerConnected = true;
+                }
+            }  
         }
 
         //Set color preset based on default color

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
@@ -88,34 +88,21 @@ public class PlayerJoinManager : MonoBehaviour
         joinPrompt.gameObject.SetActive(false);
         promptTray.gameObject.SetActive(true);
 
+        //Change Prompt Tray Icons based on which control scheme Player 1 uses
         if (pc.Order == 0)
         {
-            if (playerInput.currentControlScheme == "KnM")
+            switch (playerInput.currentControlScheme)
             {
-                for (int i = 0; i < promptTrayIcons.Count; i++)
-                {
-                    promptTrayIcons[i].sprite = keyboardInputPrompts[i];
-                    controllerConnected = false;
-                }
-            }
-
-            else if (playerInput.currentControlScheme == "PS4")
-            {
-                for (int i = 0; i < promptTrayIcons.Count; i++)
-                {
-                    promptTrayIcons[i].sprite = playstationInputPrompts[i];
-                    controllerConnected = true;
-                }
-            }
-
-            else if (playerInput.currentControlScheme == "xbox")
-            {
-                for (int i = 0; i < promptTrayIcons.Count; i++)
-                {
-                    promptTrayIcons[i].sprite = xboxInputPrompts[i];
-                    controllerConnected = true;
-                }
-            }  
+                case "KnM":
+                    ChangePromptTray(keyboardInputPrompts, false);
+                    break;
+                case "PS4":
+                    ChangePromptTray(playstationInputPrompts, true);
+                    break;
+                case "xbox":
+                    ChangePromptTray(xboxInputPrompts, true);
+                    break;
+            } 
         }
 
         //Set color preset based on default color
@@ -265,5 +252,15 @@ public class PlayerJoinManager : MonoBehaviour
     public void ExitToTitle()
     {
         SceneManager.LoadScene(0);
+    }
+
+    //Change the prompt tray icons based on the based in sprite list and whether a controller is used or not
+    private void ChangePromptTray (List<Sprite> promptSprites, bool controller)
+    {
+        for (int i = 0; i < promptTrayIcons.Count; i++)
+        {
+            promptTrayIcons[i].sprite = promptSprites[i];
+            controllerConnected = controller;
+        }
     }
 }

--- a/80s Game/Assets/Scripts/UI Scripts/OnboardingUI.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/OnboardingUI.cs
@@ -9,7 +9,8 @@ public class OnboardingUI : MonoBehaviour
     public GameObject onboardingPanel;
     public GameObject gameUIElements;
     public GameObject mouseDiagram;
-    public GameObject controllerDiagram;
+    public GameObject xboxControllerDiagram;
+    public GameObject playstationControllerDiagram;
     [SerializeField] AudioClip gameStartTheme;
     private UIManager manager;
     private bool controllerConnected = false;
@@ -21,22 +22,19 @@ public class OnboardingUI : MonoBehaviour
         //Pause game when onboarding panel is activated
         Time.timeScale = 0.0f;
 
-        foreach (PlayerConfig pc in PlayerData.activePlayers)
+        if (PlayerData.activePlayers[0].controlScheme == "KnM")
         {
-            if (pc.controlScheme != "KnM")
-            {
-                controllerConnected = true;
-            }
+            mouseDiagram.SetActive(true);
         }
 
-        if (controllerConnected)
+        else if (PlayerData.activePlayers[0].controlScheme == "xbox")
         {
-            controllerDiagram.SetActive(true);
+            xboxControllerDiagram.SetActive(true);
         }
 
         else
         {
-            mouseDiagram.SetActive(true);
+            playstationControllerDiagram.SetActive(true);
         }
     }
 

--- a/80s Game/Assets/Scripts/UI Scripts/ScoreBehavior.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/ScoreBehavior.cs
@@ -62,16 +62,17 @@ public class ScoreBehavior : MonoBehaviour
             }
         }
 
+        //Change the Pause Input Prompt for Classic Mode
         else
         {
-            if (PlayerData.activePlayers[0].controlScheme == "PS4")
+            switch (PlayerData.activePlayers[0].controlScheme)
             {
-                pauseInputPrompt.sprite = controllerPauseInputs[0];
-            }
-
-            else if (PlayerData.activePlayers[0].controlScheme == "xbox")
-            {
-                pauseInputPrompt.sprite = controllerPauseInputs[1];
+                case "PS4":
+                    pauseInputPrompt.sprite = controllerPauseInputs[0];
+                    break;
+                case "xbox":
+                    pauseInputPrompt.sprite = controllerPauseInputs[1];
+                    break;
             }
         }
     }

--- a/80s Game/Assets/Scripts/UI Scripts/ScoreBehavior.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/ScoreBehavior.cs
@@ -30,6 +30,8 @@ public class ScoreBehavior : MonoBehaviour
     private int leadingPlayer;
 
     public List<TextMeshProUGUI> playerNames;
+    public List<Sprite> controllerPauseInputs;
+    public Image pauseInputPrompt;
 
     //UI Elements for Defense mode
     public Image coreHealthbar;
@@ -57,6 +59,19 @@ public class ScoreBehavior : MonoBehaviour
             {
                 playerNames[i].gameObject.SetActive(true);
                 playerNames[i].text = PlayerData.activePlayers[i].initials;
+            }
+        }
+
+        else
+        {
+            if (PlayerData.activePlayers[0].controlScheme == "PS4")
+            {
+                pauseInputPrompt.sprite = controllerPauseInputs[0];
+            }
+
+            else if (PlayerData.activePlayers[0].controlScheme == "xbox")
+            {
+                pauseInputPrompt.sprite = controllerPauseInputs[1];
             }
         }
     }

--- a/80s Game/Assets/Scripts/UI Scripts/SettingsManager.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/SettingsManager.cs
@@ -132,22 +132,21 @@ public class SettingsManager : MonoBehaviour
             EventSystem.current.SetSelectedGameObject(null);
             EventSystem.current.SetSelectedGameObject(sfxVolumeSlider.gameObject);
 
-            if (PlayerData.activePlayers[playerIndex].controlScheme == "PS4")
+            //Change input prompts for changing tabs based on the control scheme of the player who paused
+            switch (PlayerData.activePlayers[playerIndex].controlScheme)
             {
-                tabPrompts[0].sprite = controllerTabPrompts[0];
-                tabPrompts[1].sprite = controllerTabPrompts[1];
-            }
-
-            else if (PlayerData.activePlayers[playerIndex].controlScheme == "xbox")
-            {
-                tabPrompts[0].sprite = controllerTabPrompts[2];
-                tabPrompts[1].sprite = controllerTabPrompts[3];
-            }
-
-            else
-            {
-                tabPrompts[0].sprite = controllerTabPrompts[4];
-                tabPrompts[1].sprite = controllerTabPrompts[5];
+                case "PS4":
+                    tabPrompts[0].sprite = controllerTabPrompts[0];
+                    tabPrompts[1].sprite = controllerTabPrompts[1];
+                    break;
+                case "xbox":
+                    tabPrompts[0].sprite = controllerTabPrompts[2];
+                    tabPrompts[1].sprite = controllerTabPrompts[3];
+                    break;
+                case "KnM":
+                    tabPrompts[0].sprite = controllerTabPrompts[4];
+                    tabPrompts[1].sprite = controllerTabPrompts[5];
+                    break;
             }
         }
 

--- a/80s Game/Assets/Scripts/UI Scripts/SettingsManager.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/SettingsManager.cs
@@ -34,6 +34,8 @@ public class SettingsManager : MonoBehaviour
     public List<TextMeshProUGUI> settingsLabels;
 
     public List<GameObject> tabs;
+    public List<Image> tabPrompts;
+    public List<Sprite> controllerTabPrompts;
     private int tabIndex = 0;
 
     public List<GameObject> controlMappings;
@@ -129,6 +131,24 @@ public class SettingsManager : MonoBehaviour
         {
             EventSystem.current.SetSelectedGameObject(null);
             EventSystem.current.SetSelectedGameObject(sfxVolumeSlider.gameObject);
+
+            if (PlayerData.activePlayers[playerIndex].controlScheme == "PS4")
+            {
+                tabPrompts[0].sprite = controllerTabPrompts[0];
+                tabPrompts[1].sprite = controllerTabPrompts[1];
+            }
+
+            else if (PlayerData.activePlayers[playerIndex].controlScheme == "xbox")
+            {
+                tabPrompts[0].sprite = controllerTabPrompts[2];
+                tabPrompts[1].sprite = controllerTabPrompts[3];
+            }
+
+            else
+            {
+                tabPrompts[0].sprite = controllerTabPrompts[4];
+                tabPrompts[1].sprite = controllerTabPrompts[5];
+            }
         }
 
         else

--- a/80s Game/Assets/Scripts/UI Scripts/TitleScreenBehavior.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/TitleScreenBehavior.cs
@@ -91,14 +91,15 @@ public class TitleScreenBehavior : MonoBehaviour
             EventSystem.current.SetSelectedGameObject(null);
             EventSystem.current.SetSelectedGameObject(gamemodeOptions[0].gameObject);
 
-            if (PlayerData.activePlayers[0].controlScheme == "PS4")
+            //Change the prompt icon for the Gamemode help button to the proper control scheme
+            switch (PlayerData.activePlayers[0].controlScheme)
             {
-                helpInputPrompt.sprite = controllerHelpInputs[0];
-            }
-
-            else if (PlayerData.activePlayers[0].controlScheme == "xbox")
-            {
-                helpInputPrompt.sprite = controllerHelpInputs[1];
+                case "PS4":
+                    helpInputPrompt.sprite = controllerHelpInputs[0];
+                    break;
+                case "xbox":
+                    helpInputPrompt.sprite = controllerHelpInputs[1];
+                    break;
             }
         }
         else

--- a/80s Game/Assets/Scripts/UI Scripts/TitleScreenBehavior.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/TitleScreenBehavior.cs
@@ -21,6 +21,8 @@ public class TitleScreenBehavior : MonoBehaviour
     public TextMeshProUGUI gamemodeDescription;
     public GameObject startButton;
     public List<Button> gamemodeOptions;
+    public Image helpInputPrompt;
+    public List<Sprite> controllerHelpInputs;
 
     private int gamemodeSelected = 1;
 
@@ -88,6 +90,16 @@ public class TitleScreenBehavior : MonoBehaviour
         {
             EventSystem.current.SetSelectedGameObject(null);
             EventSystem.current.SetSelectedGameObject(gamemodeOptions[0].gameObject);
+
+            if (PlayerData.activePlayers[0].controlScheme == "PS4")
+            {
+                helpInputPrompt.sprite = controllerHelpInputs[0];
+            }
+
+            else if (PlayerData.activePlayers[0].controlScheme == "xbox")
+            {
+                helpInputPrompt.sprite = controllerHelpInputs[1];
+            }
         }
         else
         {


### PR DESCRIPTION
## Summarize what is being added
-Playstation Input Prompts now display when using a Playstation Controller
-Xbox Input Prompts display when using an Xbox Controller
-Pause Prompt when playing Classic Mode now shows the proper input necessary to pause
-Help Prompt on Gamemode select screen now shows the proper button to uses
-Switch Tab prompts on Settings screen now update to the inputs for whichever player paused the game

NOTE: Some of the prompts on the Title Screen (i.e. Gamemode Help and Settings Tabs) are not accurate on the first visit to the Title Screen, since the screen can be navigated by all controllers at once it defaults to the keyboard prompts, even if those are not the buttons to change

## Please describe how to test
-Play the game as normal, take note of the input prompts throughout the game, they should match the control scheme you use
-Play Competitive mode and join using multiple control schemes, the prompt tray and onboarding diagram will use whatever scheme Player 1 is using
-Quit to the Title Screen when done playing, the prompts in the Settings menu and Gamemode help should match the scheme Player 1 of the previous game was using

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-211

## What Sprint is this due in?
Sprint 4