### PR TITLE
Fixed issue with unstable bats

### DIFF
--- a/80s Game/Assets/Prefabs/UnstableTarget.prefab
+++ b/80s Game/Assets/Prefabs/UnstableTarget.prefab
@@ -211,7 +211,7 @@ MonoBehaviour:
   FSM: {fileID: 7156282623998708221}
   bIsStunned: 0
   floatingTextPrefab: {fileID: 5422266768498237442, guid: 75dd293da92028a43b54e04a8792559c, type: 3}
-  pointValue: 1000
+  pointValue: 2000
   deathHeight: -6.5
   hitSound: {fileID: 0}
 --- !u!60 &8319351504079490042

--- a/80s Game/Assets/Scripts/AI/StateMachine/BaseBat/BatStateMachine.cs
+++ b/80s Game/Assets/Scripts/AI/StateMachine/BaseBat/BatStateMachine.cs
@@ -33,7 +33,6 @@ public class BatStateMachine : AbsStateMachine<BatStateMachine.BatStates>
     SpriteRenderer _SpriteRenderer;
     protected AnimationHandler _AnimControls;
     protected InputManager _InputManager;
-    protected PlayerController stunningPlayer;
     PolygonCollider2D _Collider;
 
 

--- a/80s Game/Assets/Scripts/AI/StateMachine/UnstableBat/UnstableBatStateMachine.cs
+++ b/80s Game/Assets/Scripts/AI/StateMachine/UnstableBat/UnstableBatStateMachine.cs
@@ -44,7 +44,7 @@ public class UnstableBatStateMachine : BatStateMachine
 
             // Play stun anim
             BatStateMachine FSM = (BatStateMachine)targetChain[i].FSM;
-            FSM.GetComponent<Target>().SetStunningPlayer(stunningPlayer);
+            FSM.GetComponent<Target>().SetStunningPlayer(currentTarg.GetStunningPlayer());
             targetChain[i].GetComponent<AnimationHandler>().PlayStunAnimation();
 
             // Update current target

--- a/80s Game/Assets/Scripts/Target.cs
+++ b/80s Game/Assets/Scripts/Target.cs
@@ -228,6 +228,11 @@ public class Target : MonoBehaviour
         stunningPlayer = controller;
     }
 
+    public PlayerController GetStunningPlayer()
+    {
+        return stunningPlayer;
+    }
+
     /// <summary>
     /// Display floating text at bat location
     /// </summary>


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
StunningPlayer variable was never removed from the BatStateMachine when the refactor happened to move behavior into Target.
Thus, the obsolete reference in the UnstableBatStateMachine never cropped up as a null reference exception.
Fixed this by making sure the UnstableBat stun process refers to the proper variable and removed the leftover reference.

## Please describe how to test
Follow the instruction as provided on the ticket.
Things should work as expected.

## Relevant Screenshots

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?assignee=712020%3A72da91bd-2f5a-4c69-861e-59715da3052a&selectedIssue=BB-218

## What Sprint is this due in?
Sprint 4