### PR TITLE
Enforced allowed checks for regular bats

### DIFF
--- a/80s Game/Assets/Scenes/CooperativeMode.unity
+++ b/80s Game/Assets/Scenes/CooperativeMode.unity
@@ -1750,6 +1750,112 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   selectable: {fileID: 198742983}
+--- !u!1001 &230363674
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1011990662}
+    m_Modifications:
+    - target: {fileID: 1035576977932210131, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_Name
+      value: LookingGlass
+      objectReference: {fileID: 0}
+    - target: {fileID: 1035576977932210131, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 831.5886
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 434.2603
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -415.7895
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 217.1258
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+--- !u!224 &230363675 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
+  m_PrefabInstance: {fileID: 230363674}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &241881593
 GameObject:
   m_ObjectHideFlags: 0
@@ -7138,6 +7244,7 @@ RectTransform:
   - {fileID: 1438820511}
   - {fileID: 455586618}
   - {fileID: 1093280407}
+  - {fileID: 230363675}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
@@ -115,15 +115,14 @@ public class ClassicMode : AbsGameMode
         for (int i = 0; i < bats.Count; i++)
         {
             Target bat = bats[i];
+            // Debug Override
+            if (debugMode && allowedBats[bat.type] && !bat.FSM.IsActive())
+            {
+                return i;
+            }
             if (SkipBat(bat))
             {
                 continue;
-            }
-
-            // Debug Override
-            if (debugMode)
-            {
-                return i;
             }
 
             // Check for special bat types

--- a/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
@@ -75,7 +75,7 @@ public class ClassicMode : AbsGameMode
         {
             int targetIndex = GetNextAvailableBat();
 
-            if (targetIndex == -1)
+            if (targetIndex == -1 && allowedBats[TargetManager.TargetType.Regular])
             {
                 targetManager.SpawnTarget(targetManager.GetNextAvailableTargetOfType<BatStateMachine>());
                 continue;
@@ -219,6 +219,8 @@ public class ClassicMode : AbsGameMode
             int targetIndex = GetNextAvailableBat();
             if (targetIndex >= 0)
                 targetManager.SpawnTarget(targetIndex);
+            else if (!allowedBats[TargetManager.TargetType.Regular])
+                return;
             else
                 targetManager.SpawnTarget(targetManager.GetNextAvailableTargetOfType<BatStateMachine>());
         }

--- a/80s Game/Assets/Scripts/GameModes/CompetitiveMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/CompetitiveMode.cs
@@ -122,15 +122,16 @@ public class CompetitiveMode : AbsGameMode
         for (int i = 0; i < bats.Count; i++)
         {
             Target bat = bats[i];
+            // Debug Override
+            // Debug Override
+            if (debugMode && allowedBats[bat.type] && !bat.FSM.IsActive())
+            {
+                return i;
+            }
+
             if (SkipBat(bat))
             {
                 continue;
-            }
-
-            // Debug Override
-            if (debugMode)
-            {
-                return i;
             }
 
             // Check for special bat types

--- a/80s Game/Assets/Scripts/GameModes/CompetitiveMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/CompetitiveMode.cs
@@ -75,7 +75,7 @@ public class CompetitiveMode : AbsGameMode
         {
             int targetIndex = GetNextAvailableBat();
 
-            if (targetIndex == -1)
+            if (targetIndex == -1 && allowedBats[TargetManager.TargetType.Regular])
             {
                 targetManager.SpawnTarget(targetManager.GetNextAvailableTargetOfType<BatStateMachine>());
                 continue;
@@ -228,6 +228,8 @@ public class CompetitiveMode : AbsGameMode
 
             if (targetIndex >= 0)
                 targetManager.SpawnTarget(targetIndex);
+            else if (!allowedBats[TargetManager.TargetType.Regular])
+                return;
             else
                 targetManager.SpawnTarget(targetManager.GetNextAvailableTargetOfType<BatStateMachine>());
         }

--- a/80s Game/Assets/Scripts/GameModes/CooperativeMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/CooperativeMode.cs
@@ -75,7 +75,7 @@ public class CooperativeMode : AbsGameMode
         {
             int targetIndex = GetNextAvailableBat();
 
-            if (targetIndex == -1)
+            if (targetIndex == -1 && allowedBats[TargetManager.TargetType.Regular])
             {
                 targetManager.SpawnTarget(targetManager.GetNextAvailableTargetOfType<BatStateMachine>());
                 continue;
@@ -201,6 +201,8 @@ public class CooperativeMode : AbsGameMode
 
             if (targetIndex >= 0)
                 targetManager.SpawnTarget(targetIndex);
+            else if (!allowedBats[TargetManager.TargetType.Regular])
+                return;
             else
                 targetManager.SpawnTarget(targetManager.GetNextAvailableTargetOfType<DefenseBatStateMachine>());
         }

--- a/80s Game/Assets/Scripts/GameModes/CooperativeMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/CooperativeMode.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using static UnityEngine.GraphicsBuffer;
 
 public class CooperativeMode : AbsGameMode
 {
@@ -115,15 +116,14 @@ public class CooperativeMode : AbsGameMode
         for (int i = 0; i < bats.Count; i++)
         {
             Target bat = bats[i];
+            // Debug Override
+            if (debugMode && allowedBats[bat.type] && !bat.FSM.IsActive())
+            {
+                return i;
+            }
             if (SkipBat(bat))
             {
                 continue;
-            }
-
-            // Debug Override
-            if (debugMode)
-            {
-                return i;
             }
 
             // Check for special bat types
@@ -173,7 +173,7 @@ public class CooperativeMode : AbsGameMode
         }
 
         // Start the next round if desired number of stuns is met
-        if (targetManager.numStuns >= currentRoundTargetCount)
+        if (targetManager.numStuns >= currentRoundTargetCount && allowedBats[TargetManager.TargetType.Modifier])
         {
             StartNextRound();
 

--- a/80s Game/Assets/Scripts/GameModes/CooperativeMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/CooperativeMode.cs
@@ -114,16 +114,20 @@ public class CooperativeMode : AbsGameMode
         // find one that isn't already on screen
         for (int i = 0; i < bats.Count; i++)
         {
-            DefenseBatStateMachine FSM = (DefenseBatStateMachine)bats[i].FSM;
-            if (FSM.bIsActive)
+            Target bat = bats[i];
+            if (SkipBat(bat))
+            {
                 continue;
+            }
 
-            ModifierDefenseBatStateMachine comp = bats[i].GetComponent<ModifierDefenseBatStateMachine>();
-            if (comp != null)
-                continue;
+            // Debug Override
+            if (debugMode)
+            {
+                return i;
+            }
 
             // Check for special bat types
-            foreach(SpawnRate rate in GameManager.Instance.spawnConfig.rates)
+            foreach (SpawnRate rate in GameManager.Instance.spawnConfig.rates)
             {
                 // Check that type isnt regular
                 if(rate.targetType != TargetManager.TargetType.Regular)
@@ -132,7 +136,7 @@ public class CooperativeMode : AbsGameMode
                     if(numBatsMap[rate.targetType] > 0)
                     {
                         // Check for proper type and continue if not
-                        if(FSM.IsDefault() || bats[i].type != rate.targetType)
+                        if(bat.FSM.IsDefault() || bats[i].type != rate.targetType)
                             goto EndLoop;
 
                         numBatsMap[rate.targetType]--;
@@ -143,7 +147,7 @@ public class CooperativeMode : AbsGameMode
 
             // If default bat return index, as there were no available
             // special bats to spawn previously
-            if (FSM.IsDefault())
+            if (bat.FSM.IsDefault())
             {
                 return i;
             }

--- a/80s Game/Assets/Scripts/GameModes/GameMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/GameMode.cs
@@ -54,7 +54,7 @@ public abstract class AbsGameMode
     {
         ModifierBatStateMachine mbsm = target.GetComponent<ModifierBatStateMachine>();
         bool isModifierBat = mbsm != null;
-        return !allowedBats[target.type] || target.FSM.IsActive() || isModifierBat;
+        return !allowedBats[target.type] || target.FSM.IsActive() || isModifierBat ;
     }
 
     // Needs to be public for targetManager to call

--- a/80s Game/Assets/Scripts/LookingGlass/SpawnPanel.cs
+++ b/80s Game/Assets/Scripts/LookingGlass/SpawnPanel.cs
@@ -25,6 +25,11 @@ public class SpawnPanel : LookingGlassPanel
         {
             spawnUIGroups.Add(type, group);
         }
+
+        if (!GameManager.Instance.ActiveGameMode.CanSpawnType(type))
+        {
+            spawnUIGroups[type].UpdateIcon(notAvailable);
+        }
     }
 
     /// <summary>

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
@@ -140,8 +140,18 @@ public class PlayerInputWrapper : MonoBehaviour
 
     private void OnLookingGlass(InputValue value)
     {
+        if (!NetworkUtility.NetworkDevEnv())
+        {
+            return;
+        }
+
         // Open the debug panel if the game is paused
-        if (Time.timeScale > 0f && !NetworkUtility.NetworkDevEnv())
+        if (Time.timeScale > 0f )
+        {
+            return;
+        }
+
+        if (!NetworkUtility.NetworkDevEnv())
         {
             return;
         }

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
@@ -141,7 +141,7 @@ public class PlayerInputWrapper : MonoBehaviour
     private void OnLookingGlass(InputValue value)
     {
         // Open the debug panel if the game is paused
-        if (Time.timeScale > 0f || NetworkUtility.NetworkDevEnv())
+        if (Time.timeScale > 0f && !NetworkUtility.NetworkDevEnv())
         {
             return;
         }

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
@@ -141,7 +141,7 @@ public class PlayerInputWrapper : MonoBehaviour
     private void OnLookingGlass(InputValue value)
     {
         // Open the debug panel if the game is paused
-        if (Time.timeScale > 0f)
+        if (Time.timeScale > 0f || NetworkUtility.NetworkDevEnv())
         {
             return;
         }


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
LookingGlass could not disable regular bats from spawning.
It can now.
Also, added LookingGlass to coop mode and constrained the tool to only be accessible on Debug/Development builds

## Please describe how to test
Play any game mode. Disable regular bats.
No regular bats should spawn.

## Relevant Screenshots
LookingGlass in Co-Op
![image](https://github.com/mythguy1226/80sgame/assets/9394777/e2c7c572-bad1-4bac-8feb-04c5e5537ec3)

Disabled regular bats
![image](https://github.com/mythguy1226/80sgame/assets/9394777/b8e54227-7d07-48a1-8dae-4a958fc7a15f)

No regular bats have spawned.
![image](https://github.com/mythguy1226/80sgame/assets/9394777/de8136ee-9e8a-4f5d-ad74-9f1a574925b3)


## Issue worked on
[Issue
](https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?assignee=712020%3A72da91bd-2f5a-4c69-861e-59715da3052a&selectedIssue=BB-222)
## What Sprint is this due in?
Sprint 4