### PR TITLE
Fixed Intro Cutscene not playing

### DIFF
--- a/80s Game/Assets/Art/Sprites/Bats/2_ModBat/modifier_bat_default.png.meta
+++ b/80s Game/Assets/Art/Sprites/Bats/2_ModBat/modifier_bat_default.png.meta
@@ -106,6 +106,19 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: 4
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []

--- a/80s Game/Assets/Scripts/UI Scripts/CutsceneManager.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/CutsceneManager.cs
@@ -12,6 +12,8 @@ public class CutsceneManager : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
+        Time.timeScale = 1f;
+
         switch (PlayerData.activePlayers[0].controlScheme)
         {
             case "PS4":


### PR DESCRIPTION
## Summarize what is being added
-The Intro Cutscene has been fixed so that it now plays any time the scene is loaded, even when quitting the game from the Game Over Screen

## Please describe how to test
-Play a game mode and reach the game over screen (Defense is the quickest mode to do so). Press the Quit button, the cutscene should play as expected
-Test other cases of loading back to the Title Screen to ensure the cutscene always plays (Quitting from pause, Quitting from Join Screen, etc.)

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-225

## What Sprint is this due in?
Sprint 4