### PR TITLE
Fixed crosshair sprite loop through and leaderboard text lineup bug

### DIFF
--- a/80s Game/Assets/Prefabs/PlayerControllers/PlayerPanel.prefab
+++ b/80s Game/Assets/Prefabs/PlayerControllers/PlayerPanel.prefab
@@ -2202,14 +2202,9 @@ MonoBehaviour:
   - {fileID: 3528867196686144335}
   crosshairSprites:
   - {fileID: 72313475, guid: b56078464c4f4214c998e28b53dbe022, type: 3}
-  - {fileID: 1215599106, guid: b56078464c4f4214c998e28b53dbe022, type: 3}
   - {fileID: -396588872, guid: b56078464c4f4214c998e28b53dbe022, type: 3}
   - {fileID: 1580000228, guid: b56078464c4f4214c998e28b53dbe022, type: 3}
-  - {fileID: -1847946462, guid: b56078464c4f4214c998e28b53dbe022, type: 3}
-  - {fileID: -964177236, guid: b56078464c4f4214c998e28b53dbe022, type: 3}
-  - {fileID: 1441806986, guid: b56078464c4f4214c998e28b53dbe022, type: 3}
-  - {fileID: 1850062563, guid: b56078464c4f4214c998e28b53dbe022, type: 3}
-  - {fileID: 931082328, guid: b56078464c4f4214c998e28b53dbe022, type: 3}
+  - {fileID: 1215599106, guid: b56078464c4f4214c998e28b53dbe022, type: 3}
   initials:
   - {fileID: 2826053891590800211}
   - {fileID: 4819140831988380133}

--- a/80s Game/Assets/Prefabs/Settings Panel.prefab
+++ b/80s Game/Assets/Prefabs/Settings Panel.prefab
@@ -7886,7 +7886,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.2735849, g: 0.2735849, b: 0.2735849, a: 1}
+  m_Color: {r: 0.2735849, g: 0.2735849, b: 0.2735849, a: 0.9411765}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/80s Game/Assets/Scenes/SampleScene.unity
+++ b/80s Game/Assets/Scenes/SampleScene.unity
@@ -4532,8 +4532,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 1.0384, y: 51}
-  m_SizeDelta: {x: 667.79, y: 471.33}
+  m_AnchoredPosition: {x: 0, y: 51}
+  m_SizeDelta: {x: 762.14, y: 471.33}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &692398610
 MonoBehaviour:
@@ -4589,7 +4589,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -6719,6 +6719,7 @@ MonoBehaviour:
   gameUIElements: {fileID: 1759806105}
   onboardingPanel: {fileID: 1561009852}
   onboardingCloseButton: {fileID: 0}
+  introCutscene: {fileID: 0}
   buttonClickSound: {fileID: 8300000, guid: 0f33d998cd03b1f4ebc4983ef2a6d559, type: 3}
   crosshairs: []
   playerIndex: 0

--- a/80s Game/Assets/Scenes/SampleScene.unity
+++ b/80s Game/Assets/Scenes/SampleScene.unity
@@ -966,7 +966,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: -280}
-  m_SizeDelta: {x: 667.79, y: 46.31}
+  m_SizeDelta: {x: 762.14, y: 46.31}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &225425478
 CanvasRenderer:
@@ -1030,7 +1030,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -2264,7 +2264,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: -125}
-  m_SizeDelta: {x: 667.79, y: 46.31}
+  m_SizeDelta: {x: 762.14, y: 46.31}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &417171214
 CanvasRenderer:
@@ -2328,7 +2328,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -3866,7 +3866,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 128}
-  m_SizeDelta: {x: 667.79, y: 46.31}
+  m_SizeDelta: {x: 762.14, y: 46.31}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &623499925
 CanvasRenderer:
@@ -3930,7 +3930,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -5936,7 +5936,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: -41}
-  m_SizeDelta: {x: 667.79, y: 46.31}
+  m_SizeDelta: {x: 762.14, y: 46.31}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &898002238
 CanvasRenderer:
@@ -6000,7 +6000,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -6489,7 +6489,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 212}
-  m_SizeDelta: {x: 667.79, y: 46.31}
+  m_SizeDelta: {x: 762.14, y: 46.31}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1008355012
 CanvasRenderer:
@@ -6553,7 +6553,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -7617,7 +7617,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 44}
-  m_SizeDelta: {x: 667.79, y: 46.31}
+  m_SizeDelta: {x: 762.14, y: 46.31}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1163611730
 CanvasRenderer:
@@ -7681,7 +7681,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -8048,7 +8048,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: -209}
-  m_SizeDelta: {x: 667.79, y: 46.31}
+  m_SizeDelta: {x: 762.14, y: 46.31}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1231367928
 CanvasRenderer:
@@ -8112,7 +8112,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
+  m_HorizontalAlignment: 2
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0

--- a/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
@@ -13,7 +13,7 @@ public class ClassicMode : AbsGameMode
         ModeType = EGameMode.Classic;
 
         // Initial round parameters
-        NumRounds = 11;
+        NumRounds = 10;
         maxTargetsOnScreen = 8;
         currentRoundTargetCount = 5;
 

--- a/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
@@ -13,7 +13,7 @@ public class ClassicMode : AbsGameMode
         ModeType = EGameMode.Classic;
 
         // Initial round parameters
-        NumRounds = 10;
+        NumRounds = 11;
         maxTargetsOnScreen = 8;
         currentRoundTargetCount = 5;
 

--- a/80s Game/Assets/Scripts/UI Scripts/PlayerJoinPanel.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/PlayerJoinPanel.cs
@@ -103,7 +103,15 @@ public class PlayerJoinPanel : MonoBehaviour
         else crosshairIndex--;
 
         //Clamp the index to the size of the available crosshairs
-        crosshairIndex = Mathf.Clamp(crosshairIndex, 0, crosshairSprites.Count - 1);
+        if (crosshairIndex == crosshairSprites.Count)
+        {
+            crosshairIndex = 0;
+        }
+
+        else if (crosshairIndex == -1)
+        {
+            crosshairIndex = crosshairSprites.Count - 1;
+        }
 
         //Change the sprite of the crosshair preview
         crosshairPreview.sprite = crosshairSprites[crosshairIndex];


### PR DESCRIPTION
## Summarize what is being added
-Crosshair Sprite selection now loops through to beginning/end when selecting an option at the end of the list
-Crosshair Sprites reduced to 4 total, rest will be added as achievement unlocks
-Also fixed the bug of leaderboard text not lining up with highlights when having a high score of 1 million or more.
-Made settings panel very slightly transparent (the flat grey felt kind of boring)

## Please describe how to test
-Play Classic Mode and cycle through the crosshairs, it should loop through when continuing the list on either end
-Check Settings Menu and see if the slight transparency makes the menu less readable or not
-Finish classic mode and make sure there's a high score of 1 million or more. The leaderboard text should still line up with the red highlights (The 1M+ score will be slightly offset from the rest)

## Issue worked on
Crosshair Issue: https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-236
Leaderboard Issue: https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-235

## What Sprint is this due in?
Sprint 5