### PR TITLE
Balanced cooperative mode per player count

### DIFF
--- a/80s Game/Assets/Prefabs/DiveBombBat.prefab
+++ b/80s Game/Assets/Prefabs/DiveBombBat.prefab
@@ -60,6 +60,7 @@ MonoBehaviour:
   pointValue: 3000
   deathHeight: -6.5
   hitSound: {fileID: 0}
+  rewiredParticles: {fileID: 0}
 --- !u!50 &4043134783524271435
 Rigidbody2D:
   serializedVersion: 4
@@ -163,12 +164,7 @@ MonoBehaviour:
   isWandering: 0
   isFleeing: 0
   maxSpeed: 6
-  maxForce: 0.03
   currentVelocity: {x: 0, y: 0}
-  flockSize: 1
-  separationStrength: 1.2
-  cohesionStrength: 0.4
-  alignmentStrength: 1
 --- !u!95 &5122440697510579374
 Animator:
   serializedVersion: 5
@@ -327,6 +323,6 @@ MonoBehaviour:
   targetLatch: {fileID: 0}
   pursueSpeedScale: 2
   bCanPursue: 0
-  attackCooldown: 0.5
+  attackCooldown: 3
   attackDamage: 3
   hitParticles: {fileID: 3537340124483570280, guid: ef47d61f4a1bdbf48a7823178aacb6be, type: 3}

--- a/80s Game/Assets/Prefabs/ModifierDefenseBat.prefab
+++ b/80s Game/Assets/Prefabs/ModifierDefenseBat.prefab
@@ -60,6 +60,7 @@ MonoBehaviour:
   pointValue: 1500
   deathHeight: -6.5
   hitSound: {fileID: 0}
+  rewiredParticles: {fileID: 0}
 --- !u!50 &4043134783524271435
 Rigidbody2D:
   serializedVersion: 4
@@ -164,12 +165,7 @@ MonoBehaviour:
   isWandering: 0
   isFleeing: 0
   maxSpeed: 6
-  maxForce: 0.03
   currentVelocity: {x: 0, y: 0}
-  flockSize: 1
-  separationStrength: 1
-  cohesionStrength: 1
-  alignmentStrength: 1
 --- !u!95 &5122440697510579374
 Animator:
   serializedVersion: 5
@@ -328,5 +324,5 @@ MonoBehaviour:
   targetLatch: {fileID: 0}
   pursueSpeedScale: 1
   bCanPursue: 0
-  attackCooldown: 0.5
+  attackCooldown: 3
   attackDamage: 1

--- a/80s Game/Assets/Prefabs/UnstableDefenseBat.prefab
+++ b/80s Game/Assets/Prefabs/UnstableDefenseBat.prefab
@@ -86,12 +86,7 @@ MonoBehaviour:
   isWandering: 0
   isFleeing: 0
   maxSpeed: 6
-  maxForce: 0.03
   currentVelocity: {x: 0, y: 0}
-  flockSize: 1.75
-  separationStrength: 1
-  cohesionStrength: 0.7
-  alignmentStrength: 1
 --- !u!95 &3464643637762033909
 Animator:
   serializedVersion: 5
@@ -309,7 +304,7 @@ MonoBehaviour:
   targetLatch: {fileID: 0}
   pursueSpeedScale: 1
   bCanPursue: 0
-  attackCooldown: 0.5
+  attackCooldown: 3
   attackDamage: 1
   chainRadius: 2
   chainLength: 3
@@ -333,3 +328,4 @@ MonoBehaviour:
   pointValue: 2000
   deathHeight: -6.5
   hitSound: {fileID: 8300000, guid: c928b956a133aa544bfa866c9b7c2b47, type: 3}
+  rewiredParticles: {fileID: 0}

--- a/80s Game/Assets/ScriptableObjects/ModifierWeights/CooperativeModeModWeights.asset
+++ b/80s Game/Assets/ScriptableObjects/ModifierWeights/CooperativeModeModWeights.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   weights:
   - modType: 1
-    chance: 0.5
+    chance: 0.3
   - modType: 4
     chance: 0.8
   - modType: 5

--- a/80s Game/Assets/Scripts/AI/StateMachine/DefenseBats/DiveBombBat/DiveBombBatStateMachine.cs
+++ b/80s Game/Assets/Scripts/AI/StateMachine/DefenseBats/DiveBombBat/DiveBombBatStateMachine.cs
@@ -46,7 +46,7 @@ public class DiveBombBatStateMachine : DefenseBatStateMachine
     /// </summary>
     IEnumerator AllowPursue()
     {
-        yield return new WaitForSeconds(2.0f);
+        yield return new WaitForSeconds(1.5f);
         bCanPursue = true;
         base.AnimControls.PlayAttackAnimation();
     }

--- a/80s Game/Assets/Scripts/GameManager.cs
+++ b/80s Game/Assets/Scripts/GameManager.cs
@@ -216,4 +216,12 @@ public class GameManager : MonoBehaviour
         DataSaver saver = DataSaveFactory.MakeSaver(true);
         StartCoroutine(saver.Save(dataToSave));
     }
+
+    /// <summary>
+    /// Returns number of players in the game
+    /// </summary>
+    public int GetPlayerCount()
+    {
+        return players.Count;
+    }
 }

--- a/80s Game/Assets/Scripts/GameModes/CooperativeMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/CooperativeMode.cs
@@ -20,6 +20,10 @@ public class CooperativeMode : AbsGameMode
         allowedBats = new Dictionary<TargetManager.TargetType, bool>();
         SetupAllowedData();
         debugMode = false;
+
+        // Get number of players to pass into scaling method
+        int playerCount = GameManager.Instance.GetPlayerCount();
+        ScaleGameValues(playerCount);
     }
 
     protected override void SetupAllowedData()
@@ -223,5 +227,36 @@ public class CooperativeMode : AbsGameMode
     {
         GameOver = true;
         EndGame();
+    }
+
+    /// <summary>
+    /// Method takes in number of players and updates initial
+    /// values to scale. The more players the more difficulty
+    /// the game is balanced to.
+    /// </summary>
+    public void ScaleGameValues(int playerCount)
+    {
+        // Subtract 1 from count value for scale
+        int valueScale = playerCount - 1;
+
+        // Increase target counts by value scale
+        maxTargetsOnScreen += (2 * valueScale);
+        currentRoundTargetCount += (2 * valueScale);
+
+        // Modify target values based on scale
+        List<Target> bats = targetManager.targets;
+        for (int i = 0; i < bats.Count; i++)
+        {
+            // Affect only defense bats
+            DefenseBatStateMachine dFSM = bats[i].GetComponent<DefenseBatStateMachine>();
+            if(dFSM == null)
+                continue;
+
+            // Decrease timers/cooldowns and increase speed
+            dFSM.timeUntilPursue -= (0.5f * valueScale);
+            dFSM.attackCooldown -= (0.5f * valueScale);
+            dFSM.pursueSpeedScale += (0.1f * valueScale);
+        }
+
     }
 }


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
- Balanced cooperative mode to be balanced per player count
- Decreased pursue timer slightly for dive bomb bats
- Fixed attack cooldowns for some prefabs
- More players now = more difficulty

## Please describe how to test
Play cooperative mode in singleplayer to see the base difficulty, then play with a second controller. Some values may show subtle differences but are overall intended to make things more difficult. Open to changing the set values to be more or less challenging as well.

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-232

## What Sprint is this due in?
Sprint 5