### PR TITLE
Fixed background customization bug

### DIFF
--- a/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
@@ -72,7 +72,7 @@ public class PlayerInputWrapper : MonoBehaviour
     {
         if (GameManager.Instance.UIManager.titleScreenUI != null)
         {
-            if (GameManager.Instance.UIManager.titleScreenUI.gamemodePanel.activeInHierarchy)
+            if (GameManager.Instance.UIManager.titleScreenUI.gamemodePanel.activeInHierarchy && PlayerData.activePlayers[player.Order].controlScheme != "KnM")
             {
                 GameManager.Instance.UIManager.BackgroundCycle(value.Get<Vector2>());
             }


### PR DESCRIPTION
## Summarize what is being added
-Background customization no longer bugs out on mouse when using gamemode selection after quitting game

## Please describe how to test
-Play the game on mouse and go into a game, quit to the title, open game mode selection screen
-Background should not change when moving mouse

## Issue worked on
No outstanding issue

## What Sprint is this due in?
Sprint 5