### PR TITLE
Bug/infinite shot

### DIFF
--- a/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
@@ -86,7 +86,10 @@ public class PlayerController : MonoBehaviour
             activeCrosshair.SetCrosshairSprite(pc.crosshairSprite);
             activeCrosshair.ChangeSpriteColor(pc.crossHairColor);
 
-            hitParticles = pc.stunParticles;
+            if (pc.stunParticles != null)
+            {
+                hitParticles = pc.stunParticles;
+            }
 
             //Set initials under crosshair only in Competitive and Defense mode
             if (GameManager.Instance.gameModeType == EGameMode.Competitive || GameManager.Instance.gameModeType == EGameMode.Defense)


### PR DESCRIPTION
Fixed:
* Infinite shot bug caused by unguarded hit particle assignment

To Test:
Open any game mode without customizing your profile and play

No related issues

Completed during Sprint 5