### PR TITLE
Reward queueing and achievement data expansion

### DIFF
--- a/80s Game/Assets/Scripts/Achievement/AchievementData.cs
+++ b/80s Game/Assets/Scripts/Achievement/AchievementData.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 [CreateAssetMenu(menuName ="ScriptableObjects/Achievement")]
@@ -26,6 +27,9 @@ public class AchievementData : ScriptableObject
     public int testValue;
 
     public Sprite image;
+
+    public string rewardText;
+    public List<Sprite> rewardSprites;
     
     //Defer this test to the AchievementManager, just in case
     public bool isUnlocked()

--- a/80s Game/Assets/Scripts/Achievement/AchievementManager.cs
+++ b/80s Game/Assets/Scripts/Achievement/AchievementManager.cs
@@ -1,11 +1,13 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Rendering;
 using static AchievementData;
 
 public static class AchievementManager
 {
     public static Dictionary<string, int> requirements;
     private static Dictionary<string, AchievementData> lookupTable;
+    private static Queue<string> rewards;
 
     /// <summary>
     /// Register the requirement values for unlocking achievements.
@@ -21,6 +23,17 @@ public static class AchievementManager
             requirements[achievement.internalAchivementKey] = achievement.testValue;
             lookupTable[achievement.internalAchivementKey] = achievement;
         }
+    }
+
+    public static AchievementData GetNextReward()
+    {
+        if (rewards.Count == 0)
+        {
+            return null;
+        }
+
+        string achievementKey = rewards.Dequeue();
+        return lookupTable[achievementKey];
     }
 
     /// <summary>
@@ -62,6 +75,7 @@ public static class AchievementManager
     {
         Debug.Log("Unlocking Achievement " + name);
         PlayerPrefs.SetInt(name , 1);
+        rewards.Enqueue(name);
         TestForPlat();
     }
 

--- a/80s Game/Assets/Scripts/Achievement/AchievementManager.cs
+++ b/80s Game/Assets/Scripts/Achievement/AchievementManager.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Rendering;
 using static AchievementData;
 
 public static class AchievementManager
@@ -15,13 +14,17 @@ public static class AchievementManager
     /// <param name="achievements">The list of achievements in the game</param>
     public static void RegisterRequirements(List<AchievementData> achievements)
     {
-        requirements = new Dictionary<string, int>();
-        lookupTable = new Dictionary<string, AchievementData>();
-        for (int i = 0; i < achievements.Count; i++)
+        if (requirements.Count == 0)
         {
-            AchievementData achievement = achievements[i];
-            requirements[achievement.internalAchivementKey] = achievement.testValue;
-            lookupTable[achievement.internalAchivementKey] = achievement;
+            requirements = new Dictionary<string, int>();
+            lookupTable = new Dictionary<string, AchievementData>();
+            rewards = new Queue<string>();
+            for (int i = 0; i < achievements.Count; i++)
+            {
+                AchievementData achievement = achievements[i];
+                requirements[achievement.internalAchivementKey] = achievement.testValue;
+                lookupTable[achievement.internalAchivementKey] = achievement;
+            }
         }
     }
 


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Added the ability to queue rewards so they can be dequeued as necessary.

## Please describe how to test
Set up a point for dequeueing.
Get an achievement
Return to your dequeuing point - there should be data returned

## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->

## Issue worked on
No issue

## What Sprint is this due in?
Sprint 5