### PR TITLE
Fixed Audio Playback Through Scene Transitions

### DIFF
--- a/80s Game/Assets/Scripts/SoundManager.cs
+++ b/80s Game/Assets/Scripts/SoundManager.cs
@@ -70,7 +70,7 @@ public class SoundManager : MonoBehaviour
             maxPoolSize
         );
 
-        _bIsMusicPlaying = true;
+        _bIsMusicPlaying = false;
         _nextEventTime = AudioSettings.dspTime + 0.5f;
     }
 
@@ -148,18 +148,11 @@ public class SoundManager : MonoBehaviour
     {
         if (clip != null && clip.Clip != null)
         {
-            //if (_bIsMusicPlaying) //outdated, but keeping here in case we end up needing it.
-            //{
-            //    foreach (AudioSource aS in _musicLoopSources)
-            //    {
-            //        aS.volume *= 0.2f; //sets the volume of the _musicLoopSources to 20%.
-            //    }
-            //}
             continuousSource.PlayOneShot(clip.Clip, _musicVolume);
-            //StartCoroutine(NonloopUnmute(clip)); //starts a coroutine to unmute the _musicLoopSources
         }
     }
     /// <summary>
+    /// <b><i>CURRENTLY UNUSED</i></b>
     /// Coroutine to time unmuting the _musicLoopSources.
     /// Should <i>only</i> be called by methods that mute and unmute the BGM.
     /// </summary>
@@ -175,6 +168,8 @@ public class SoundManager : MonoBehaviour
             aS.volume = _musicVolume;
         }
     }
+
+
     /// <summary>
     /// Immediately stop whatever looping track is playing.
     /// </summary>
@@ -187,6 +182,17 @@ public class SoundManager : MonoBehaviour
         }
 
         _bIsMusicPlaying = false;
+    }
+    /// <summary>
+    /// Immediately stops all currently playing audio sources.
+    /// Also clears the pitchedAudioSources pool.
+    /// </summary>
+    public void StopAllAudio()
+    {
+        StopMusicLoop();
+        continuousSource.Stop();
+        interruptSource.Stop();
+        pitchedAudioSources.Clear();
     }
 
 
@@ -207,23 +213,22 @@ public class SoundManager : MonoBehaviour
         //probably dangerous, but shouldn't need to be triggered anyway
         if (_musicLoopSources == null || _musicLoopSources.Length == 0)
         {
-
             _musicLoopSources = new AudioSource[2];
-            _musicLoopSources[0] = new AudioSource();
+            _musicLoopSources[0] = gameObject.AddComponent<AudioSource>();
             _musicLoopSources[0].volume = _musicVolume;
-            _musicLoopSources[1] = new AudioSource();
+            _musicLoopSources[1] = gameObject.AddComponent<AudioSource>();
             _musicLoopSources[1].volume = _musicVolume;
         }
         else
         {
             if (_musicLoopSources[0] == null)
             {
-                _musicLoopSources[0] = new AudioSource();
+                _musicLoopSources[0] = gameObject.AddComponent<AudioSource>();
                 _musicLoopSources[0].volume = _musicVolume;
             }
             if (_musicLoopSources[1] == null)
             {
-                _musicLoopSources[1] = new AudioSource();
+                _musicLoopSources[1] = gameObject.AddComponent<AudioSource>();
                 _musicLoopSources[1].volume = _musicVolume;
             }
         }
@@ -232,7 +237,7 @@ public class SoundManager : MonoBehaviour
         if (clip != null)
         {
             //duplicates clip and overwrites _musicLoopClip.
-            _musicLoopClip = new MusicTrack(clip);
+            _musicLoopClip = clip;
 
             //schedules the music to start looping after 1 second or after the intro is finished, whichever would be longer.
             //defaults to 0, as not every looping song will have an intro (e.g. the Title theme).

--- a/80s Game/Assets/Scripts/UI Scripts/GameOverBehavior.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/GameOverBehavior.cs
@@ -94,13 +94,14 @@ public class GameOverBehavior : MonoBehaviour
 
         EventSystem.current.SetSelectedGameObject(null);
         EventSystem.current.SetSelectedGameObject(restartButton);
-
+        SoundManager.Instance.StopAllAudio();
         SoundManager.Instance.PlaySoundInterrupt(buttonClickSound);
     }
 
     //Restart the game by reloading the scene
     public void RestartGame()
     {
+        SoundManager.Instance.StopAllAudio();
         SoundManager.Instance.PlaySoundContinuous(buttonClickSound);
         SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
     }

--- a/80s Game/Assets/Scripts/UI Scripts/PauseScreenBehavior.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/PauseScreenBehavior.cs
@@ -139,7 +139,7 @@ public class PauseScreenBehavior : MonoBehaviour
         Time.timeScale = 1f;
 
         SceneManager.LoadScene(0);
-
+        SoundManager.Instance.StopAllAudio();
         SoundManager.Instance.PlaySoundContinuous(buttonClickSound);
     }
 

--- a/80s Game/Assets/Scripts/UI Scripts/TitleScreenBehavior.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/TitleScreenBehavior.cs
@@ -60,8 +60,8 @@ public class TitleScreenBehavior : MonoBehaviour
     //Used within the StartGame button element
     public void StartGame()
     {
+        SoundManager.Instance.StopAllAudio();
         SoundManager.Instance.PlaySoundContinuous(buttonClickSound);
-        SoundManager.Instance.StopMusicLoop();
         PlayerData.Reset();
         SceneManager.LoadScene(1);
     }
@@ -70,6 +70,7 @@ public class TitleScreenBehavior : MonoBehaviour
     //Used within the ExitGame button element
     public void ExitGame()
     {
+        SoundManager.Instance.StopAllAudio();
         SoundManager.Instance.PlaySoundContinuous(buttonClickSound);
 #if UNITY_EDITOR
         UnityEditor.EditorApplication.isPlaying = false;


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
<!--- Can use bullet lists here to cover new additions, but give a bit more detail than what is given in commit messages --->
Added StopAllAudio() to SoundManager, which stops all AudioSources and clears the pitchedAudioSource pool. This method is called before all scene transitions.

Also fixed several manual instantiations via "new" in SoundManager. The proper methods are now used.

## Please describe how to test
<!---Give the important steps needed for testing your main changes--->
Go into any game mode and fiddle with the game.
Try quitting to Title Screen while the round transition sound is playing: it should now stop as soon as the button is pressed.
## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->

## Issue worked on
<!---Paste in a link to the issue this PR addresses--->
<a href=https://discord.com/channels/1153826397337427981/1266465212806991952>Not an issue, but here's the QA ticket.</a>
## What Sprint is this due in?
<!---Only need to indicate here which week/deliverable the PR is for--->
Sprint 6/next week