### PR TITLE
Background Scaling Bugfixes

### DIFF
--- a/80s Game/Assets/Scenes/CompetitiveMode.unity
+++ b/80s Game/Assets/Scenes/CompetitiveMode.unity
@@ -10515,8 +10515,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 1.2199707, y: 0.010009766}
+  m_SizeDelta: {x: 22.080032, y: 24.530006}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1270203349
 MonoBehaviour:

--- a/80s Game/Assets/Scenes/CompetitiveMode.unity
+++ b/80s Game/Assets/Scenes/CompetitiveMode.unity
@@ -6222,7 +6222,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.012, y: 0.4091, z: 108.01}
-  m_LocalScale: {x: 0.92867047, y: 0.93214387, z: 1}
+  m_LocalScale: {x: 0.9286485, y: 0.9264876, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}

--- a/80s Game/Assets/Scenes/CooperativeMode.unity
+++ b/80s Game/Assets/Scenes/CooperativeMode.unity
@@ -5654,7 +5654,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4465489726597189869, guid: b1bc8a45fe191ba448c97f3b5b8cf6cb, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5.09
+      value: 5.12
       objectReference: {fileID: 0}
     - target: {fileID: 4465489726597189869, guid: b1bc8a45fe191ba448c97f3b5b8cf6cb, type: 3}
       propertyPath: m_LocalPosition.y
@@ -6657,7 +6657,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.018799, y: 0.3987, z: 108.01}
-  m_LocalScale: {x: 0.9201502, y: 0.9201502, z: 0.14156157}
+  m_LocalScale: {x: 0.9286485, y: 0.9264876, z: 0.14156157}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -9597,7 +9597,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4465489726597189869, guid: b1bc8a45fe191ba448c97f3b5b8cf6cb, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -5.01
+      value: -5.08
       objectReference: {fileID: 0}
     - target: {fileID: 4465489726597189869, guid: b1bc8a45fe191ba448c97f3b5b8cf6cb, type: 3}
       propertyPath: m_LocalPosition.y

--- a/80s Game/Assets/Scenes/CooperativeMode.unity
+++ b/80s Game/Assets/Scenes/CooperativeMode.unity
@@ -1898,7 +1898,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1035576977932210131, guid: 97534f9267428ea42800058db77cbf79, type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4213754377191692115, guid: 97534f9267428ea42800058db77cbf79, type: 3}
       propertyPath: m_Pivot.x
@@ -4331,7 +4331,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.000018597, y: 396}
+  m_AnchoredPosition: {x: 0, y: 423}
   m_SizeDelta: {x: 487.3864, y: 78.2676}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &442948580
@@ -4948,7 +4948,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6e5e2c741e414724bb82e6b18576760a, type: 3}
   m_Name: 
@@ -10212,8 +10212,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 1.2199707, y: 0.010009766}
+  m_SizeDelta: {x: 22.08, y: 24.53}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1270203349
 MonoBehaviour:

--- a/80s Game/Assets/Scenes/SampleScene.unity
+++ b/80s Game/Assets/Scenes/SampleScene.unity
@@ -8420,8 +8420,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 1.2199707, y: 0.010009766}
+  m_SizeDelta: {x: 22.080017, y: 24.530006}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1270203349
 MonoBehaviour:

--- a/80s Game/Assets/Scenes/SampleScene.unity
+++ b/80s Game/Assets/Scenes/SampleScene.unity
@@ -5032,7 +5032,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.012, y: 0.4091, z: 108.01}
-  m_LocalScale: {x: 0.92867047, y: 0.93214387, z: 1}
+  m_LocalScale: {x: 0.9286485, y: 0.9264876, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -7264,6 +7264,7 @@ MonoBehaviour:
   titleScreenUI: {fileID: 0}
   scoreBehavior: {fileID: 0}
   backgroundUI: {fileID: 0}
+  achievementsUI: {fileID: 0}
   classicModeBackgrounds:
   - {fileID: 21300000, guid: adc65da9af63f8941ab6f09c18774659, type: 3}
   - {fileID: 21300000, guid: 4fdaf93c4ae21d14689ceaaddeac185c, type: 3}


### PR DESCRIPTION
## Summarize what is being added
-Game Background now has a consistent scale across all modes, to avoid backgrounds from being smaller than the camera which results in cornflower blue borders
-Pause Screen borders in each mode have also been adjusted so it does not appear smaller than the camera when CRT Effect is off

## Please describe how to test
NOTE: Make sure you test this branch with the CRT Effect OFF

-Play a game of Defense mode, the background should be scaled properly with no cornflower blue edges
-Play each game mode and pause, there should no longer be any edges of the screen that are not dimmed when paused

## Issue worked on
No issue on board

## What Sprint is this due in?
Sprint 6