### PR TITLE
Overheat venting mechanics

### DIFF
--- a/80s Game/Assets/Prefabs/PlayerControllers/PlayerController.prefab
+++ b/80s Game/Assets/Prefabs/PlayerControllers/PlayerController.prefab
@@ -101,7 +101,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   mouseSensitivity: {x: 1, y: 1}
   controllerSensitivity: {x: 5, y: 5}
-  fireDelay: 0.2
+  fireDelay: 0.27
   controllerInput: 0
   isFlipped: 0
   isSlowed: 0

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
@@ -165,12 +165,21 @@ public class PlayerController : MonoBehaviour
         _overheat.AddHeat();
         ShotInformation s = new(activeCrosshair.transform.position, this, modifiedShotRadius != originalShotRadius);
         InputManager.PlayerShot(s);
+
+        if (_overheat.IsVenting())
+        {
+            activeCrosshair.EnableVentEffects();
+        }
     }
 
     private void Update()
     {
         _overheat.ReduceHeat(Time.deltaTime);
         activeCrosshair.overheatUI.fillAmount = _overheat.GetHeatProportion();
+        if (!_overheat.IsVenting())
+        {
+            activeCrosshair.StopVentEffects();
+        }
     }
 
     /// <summary>

--- a/80s Game/Assets/Scripts/Overheat/Overheat.cs
+++ b/80s Game/Assets/Scripts/Overheat/Overheat.cs
@@ -6,6 +6,8 @@ public class Overheat
     private float _heatLossFactor;
     private float _originalHeadAddFactor;
     private float _heatAddFactor;
+    private float _emergencyVentFactor;
+    private bool _bIsVenting;
     
     public Overheat(float maxHeat, float maxOverheat, float lossFactor, float addFactor)
     {
@@ -13,8 +15,10 @@ public class Overheat
         _maxOverheat = maxOverheat;
         _currentHeat = 0;
         _heatLossFactor = lossFactor;
+        _emergencyVentFactor = 2 * _heatLossFactor;
         _originalHeadAddFactor = addFactor;
         _heatAddFactor = addFactor;
+        _bIsVenting = false;
     }
 
     public float AddHeat()
@@ -23,6 +27,10 @@ public class Overheat
         if (_currentHeat > _maxOverheat)
         {
             _currentHeat = _maxOverheat;
+        }
+        if (_currentHeat >= _maxHeat)
+        {
+            _bIsVenting = true;
         }
         return _currentHeat;
     }
@@ -39,16 +47,27 @@ public class Overheat
 
     public float ReduceHeat(float timeDelta)
     {
-        _currentHeat -= timeDelta * _heatLossFactor;
+        float factorToUse = _heatLossFactor;
+        if ( _bIsVenting)
+        {
+            factorToUse = _emergencyVentFactor;
+        }
+        _currentHeat -= timeDelta * factorToUse;
         if ( _currentHeat < 0)
         {
             _currentHeat = 0;
+            _bIsVenting = false;
         }
         return _currentHeat;
     }
 
     public bool CanShoot() { 
-        return _currentHeat <= _maxHeat;
+        return _currentHeat <= _maxHeat && !_bIsVenting;
+    }
+
+    public bool IsVenting()
+    {
+        return _bIsVenting;
     }
 
     public float GetHeatProportion()

--- a/80s Game/Assets/Scripts/UI Scripts/Crosshair.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/Crosshair.cs
@@ -18,6 +18,9 @@ public class Crosshair : MonoBehaviour
     float jigglePhaseShift = 2.0f;
     float currentJiggleTimer;
 
+    Color startColor;
+    Color endColor;
+
     private void Awake()
     {
         sprite = GetComponent<SpriteRenderer>();
@@ -26,6 +29,8 @@ public class Crosshair : MonoBehaviour
         Cursor.visible = false;
         currentJiggleTimer = 0.0f;
         _bIsJiggling = false;
+        startColor = overheatUI.color;
+        endColor = new Color(1f, 0.5f, 0f);
     }
 
     void Update()
@@ -37,6 +42,7 @@ public class Crosshair : MonoBehaviour
             currentJiggleTimer += Time.deltaTime;
             jiggleOffsetX = Mathf.Sin(jiggleFrequency * currentJiggleTimer) * jiggleWidth;
             jiggleOffsetY = Mathf.Sin(jiggleFrequency * currentJiggleTimer + jigglePhaseShift) * jiggleHeight;
+            overheatUI.color = Color.Lerp(startColor, endColor, Mathf.Sin(jiggleFrequency * currentJiggleTimer * 0.5f) * 0.5f + 0.5f);
         }
 
         float finalX = transform.position.x + movementDelta.x + jiggleOffsetX;
@@ -124,5 +130,6 @@ public class Crosshair : MonoBehaviour
     {
         _bIsJiggling = false;
         currentJiggleTimer = 0;
+        overheatUI.color = startColor;
     }
 }

--- a/80s Game/Assets/Scripts/UI Scripts/Crosshair.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/Crosshair.cs
@@ -11,6 +11,12 @@ public class Crosshair : MonoBehaviour
 
     //Cursor clamping
     float minY, maxY, minX, maxX;
+    bool _bIsJiggling;
+    float jiggleWidth = 0.01f;
+    float jiggleHeight = 0.008f;
+    float jiggleFrequency = 50.0f;
+    float jigglePhaseShift = 2.0f;
+    float currentJiggleTimer;
 
     private void Awake()
     {
@@ -18,11 +24,24 @@ public class Crosshair : MonoBehaviour
         SetClamps();
         //Hide mouse cursor
         Cursor.visible = false;
+        currentJiggleTimer = 0.0f;
+        _bIsJiggling = false;
     }
 
     void Update()
     {
-        Vector3 newPosition = Clamp(new Vector3(transform.position.x + movementDelta.x, transform.position.y + movementDelta.y, transform.position.z));
+        float jiggleOffsetX = 0.0f;
+        float jiggleOffsetY = 0.0f;
+        if (_bIsJiggling)
+        {
+            currentJiggleTimer += Time.deltaTime;
+            jiggleOffsetX = Mathf.Sin(jiggleFrequency * currentJiggleTimer) * jiggleWidth;
+            jiggleOffsetY = Mathf.Sin(jiggleFrequency * currentJiggleTimer + jigglePhaseShift) * jiggleHeight;
+        }
+
+        float finalX = transform.position.x + movementDelta.x + jiggleOffsetX;
+        float finalY = transform.position.y + movementDelta.y + jiggleOffsetY;
+        Vector3 newPosition = Clamp(new Vector3(finalX, finalY, transform.position.z));
         transform.position = newPosition;
     }
 
@@ -94,5 +113,16 @@ public class Crosshair : MonoBehaviour
     public void SetCrosshairSprite(Sprite newSprite)
     {
         sprite.sprite = newSprite;
+    }
+
+    public void EnableVentEffects()
+    {
+        _bIsJiggling = true;
+    }
+
+    public void StopVentEffects()
+    {
+        _bIsJiggling = false;
+        currentJiggleTimer = 0;
     }
 }

--- a/80s Game/Assets/Scripts/UI Scripts/Crosshair.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/Crosshair.cs
@@ -12,8 +12,8 @@ public class Crosshair : MonoBehaviour
     //Cursor clamping
     float minY, maxY, minX, maxX;
     bool _bIsJiggling;
-    float jiggleWidth = 0.01f;
-    float jiggleHeight = 0.008f;
+    float jiggleWidth = 0.005f;
+    float jiggleHeight = 0.003f;
     float jiggleFrequency = 50.0f;
     float jigglePhaseShift = 2.0f;
     float currentJiggleTimer;


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Added an overheat venting timer. When a player exceeds max heat, their gun requires venting.
If venting, they can't shoot and their crosshair moves noisily to indicate the overheat.
Venting happens twice as fast as regular cooling of the gun.

## Please describe how to test
Play classic. Be very liberal with your shots.

You should see the gun reach overheat and require venting, during which time you won't be allowed to shoot.

## Relevant Screenshots
Can't show

## Issue worked on
No issue created

## What Sprint is this due in?
sprint 6