### PR TITLE
Hunting down the unstunnable bat bug

### DIFF
--- a/80s Game/Assets/Scripts/AI/StateMachine/DefenseBats/BaseDefenseBat/AttackingState.cs
+++ b/80s Game/Assets/Scripts/AI/StateMachine/DefenseBats/BaseDefenseBat/AttackingState.cs
@@ -21,6 +21,7 @@ public class AttackingState : AbsBaseState<DefenseBatStateMachine.DefenseBatStat
     {
         OwnerFSM.GetComponent<CircleCollider2D>().isTrigger = false;
         OwnerFSM.GetComponent<PolygonCollider2D>().isTrigger = false;
+        OwnerFSM.gameObject.GetComponent<Target>().bIsStunned = false;
     }
 
     /*

--- a/80s Game/Assets/Scripts/AI/StateMachine/DefenseBats/BaseDefenseBat/PursuingState.cs
+++ b/80s Game/Assets/Scripts/AI/StateMachine/DefenseBats/BaseDefenseBat/PursuingState.cs
@@ -20,11 +20,12 @@ public class PursuingState : AbsBaseState<DefenseBatStateMachine.DefenseBatState
     public override void EnterState()
     {
         // Get state machine and needed components
+        
         DefenseBatStateMachine FSM = (DefenseBatStateMachine)OwnerFSM;
 
         if (FSM == null)
             return;
-
+        OwnerFSM.gameObject.GetComponent<Target>().bIsStunned = false;
         _MovementControls = FSM.MovementControls;
 
         // Early return if movement controller is null

--- a/80s Game/Assets/Scripts/AI/StateMachine/DefenseBats/BaseDefenseBat/WanderingState.cs
+++ b/80s Game/Assets/Scripts/AI/StateMachine/DefenseBats/BaseDefenseBat/WanderingState.cs
@@ -19,7 +19,7 @@ public class WanderingState : AbsBaseState<DefenseBatStateMachine.DefenseBatStat
 	*/
     public override void EnterState()
     {
-        
+        OwnerFSM.gameObject.GetComponent<Target>().bIsStunned = false;
     }
 
     /*

--- a/80s Game/Assets/Scripts/AI/StateMachine/DefenseBats/ModifierDefenseBat/ModifierDefenseBatStateMachine.cs
+++ b/80s Game/Assets/Scripts/AI/StateMachine/DefenseBats/ModifierDefenseBat/ModifierDefenseBatStateMachine.cs
@@ -32,7 +32,7 @@ public class ModifierDefenseBatStateMachine : DefenseBatStateMachine
         {
             List<GameObject> buffs = GameManager.Instance.GetBuffs();
             List<GameObject> debuffs = GameManager.Instance.GetDebuffs();
-            Debug.Log("Debuffs: " + debuffs.Count.ToString());
+
             //Compose available modifiers into single list
             List<GameObject> modifierObjects = new List<GameObject>();
             foreach(GameObject buff in buffs)

--- a/80s Game/Assets/Scripts/Target.cs
+++ b/80s Game/Assets/Scripts/Target.cs
@@ -174,6 +174,10 @@ public class Target : MonoBehaviour
     /// </summary>
     public void ResolveHit()
     {
+        if (bIsStunned)
+        {
+            return;
+        }
         FSM.ResolveEvent();
     }
 


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Added two guard clauses to prevent the appearance of the unstunnable bat in defense mode:
Prevented EMP/Unstunnable bat race condition problems
Included an on-enter wandering state to turn off the bIsStunned parameter

## Please describe how to test
Play Defense Mode, play it as much as you can. Report if you find an unstunnable bat.

## Relevant Screenshots
Nothing to show

## Issue worked on
Unstunnable Bat

## What Sprint is this due in?
Sprint 6