### PR TITLE
Per-game-mode overheat parameters

### DIFF
--- a/80s Game/Assets/Scenes/CompetitiveMode.unity
+++ b/80s Game/Assets/Scenes/CompetitiveMode.unity
@@ -6841,6 +6841,7 @@ MonoBehaviour:
   - {fileID: 55702376141867145, guid: 1711ae630a5eadd4c811d1c70c1e9b7b, type: 3}
   - {fileID: 55702376141867145, guid: 367a188d6de1eb74aa7ebbdba130f295, type: 3}
   weightConfig: {fileID: 11400000, guid: c18d401095f54e24a8c3561dd18461ff, type: 2}
+  overheatParams: {fileID: 11400000, guid: e1de01000cc45ce499d18858f20d2098, type: 2}
   debug: 1
   spawnConfig: {fileID: 11400000, guid: 6baa1790f5e64ae4ea8e3ff6d99e2115, type: 2}
   maxForce: 0.25

--- a/80s Game/Assets/Scenes/CooperativeMode.unity
+++ b/80s Game/Assets/Scenes/CooperativeMode.unity
@@ -7198,6 +7198,7 @@ MonoBehaviour:
   - {fileID: 55702376141867145, guid: 1711ae630a5eadd4c811d1c70c1e9b7b, type: 3}
   - {fileID: 55702376141867145, guid: 367a188d6de1eb74aa7ebbdba130f295, type: 3}
   weightConfig: {fileID: 11400000, guid: 483adbc0aeedb274f86e7b7863993e67, type: 2}
+  overheatParams: {fileID: 11400000, guid: 927d126a21b8ff24dad82b10f4cd79df, type: 2}
   debug: 1
   spawnConfig: {fileID: 11400000, guid: ed0fbc7bf94ec6c48917bb2b3ff2984d, type: 2}
   maxForce: 0.25

--- a/80s Game/Assets/Scenes/SampleScene.unity
+++ b/80s Game/Assets/Scenes/SampleScene.unity
@@ -5224,6 +5224,7 @@ MonoBehaviour:
   - {fileID: 55702376141867145, guid: 1711ae630a5eadd4c811d1c70c1e9b7b, type: 3}
   - {fileID: 55702376141867145, guid: 367a188d6de1eb74aa7ebbdba130f295, type: 3}
   weightConfig: {fileID: 11400000, guid: f8f4ebc440b07674286e2139cca876b5, type: 2}
+  overheatParams: {fileID: 11400000, guid: 5f22d63a963522c418d46e3254c8d5eb, type: 2}
   debug: 1
   spawnConfig: {fileID: 11400000, guid: 8833365eba3dfd44dab0ebfc78fd1fe5, type: 2}
   maxForce: 0.25

--- a/80s Game/Assets/ScriptableObjects/OverheatParameters.meta
+++ b/80s Game/Assets/ScriptableObjects/OverheatParameters.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e230ab267e9f1d24880e4b7c494bef6b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/80s Game/Assets/ScriptableObjects/OverheatParameters/Classic.asset
+++ b/80s Game/Assets/ScriptableObjects/OverheatParameters/Classic.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b399ed9be39fac408ed62015fd13516, type: 3}
+  m_Name: Classic
+  m_EditorClassIdentifier: 
+  overheatMax: 60
+  maxShootOverheat: 55
+  heatAdd: 5
+  heatRemove: 10

--- a/80s Game/Assets/ScriptableObjects/OverheatParameters/Classic.asset.meta
+++ b/80s Game/Assets/ScriptableObjects/OverheatParameters/Classic.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f22d63a963522c418d46e3254c8d5eb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/80s Game/Assets/ScriptableObjects/OverheatParameters/Competitive.asset
+++ b/80s Game/Assets/ScriptableObjects/OverheatParameters/Competitive.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b399ed9be39fac408ed62015fd13516, type: 3}
+  m_Name: Competitive
+  m_EditorClassIdentifier: 
+  overheatMax: 60
+  maxShootOverheat: 55
+  heatAdd: 5
+  heatRemove: 10

--- a/80s Game/Assets/ScriptableObjects/OverheatParameters/Competitive.asset.meta
+++ b/80s Game/Assets/ScriptableObjects/OverheatParameters/Competitive.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e1de01000cc45ce499d18858f20d2098
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/80s Game/Assets/ScriptableObjects/OverheatParameters/Defense.asset
+++ b/80s Game/Assets/ScriptableObjects/OverheatParameters/Defense.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b399ed9be39fac408ed62015fd13516, type: 3}
+  m_Name: Defense
+  m_EditorClassIdentifier: 
+  overheatMax: 70
+  maxShootOverheat: 60
+  heatAdd: 5
+  heatRemove: 12

--- a/80s Game/Assets/ScriptableObjects/OverheatParameters/Defense.asset.meta
+++ b/80s Game/Assets/ScriptableObjects/OverheatParameters/Defense.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 927d126a21b8ff24dad82b10f4cd79df
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/80s Game/Assets/Scripts/GameManager.cs
+++ b/80s Game/Assets/Scripts/GameManager.cs
@@ -34,6 +34,7 @@ public class GameManager : MonoBehaviour
     public List<GameObject> debuffs;
     public List<GameObject> selfDebuffs;
     public ModifierWeightsConfig weightConfig;
+    public OverheatParameters overheatParams;
 
     List<GameObject> debugBuffs;
     List<GameObject> debugDebuffs;
@@ -85,6 +86,7 @@ public class GameManager : MonoBehaviour
                 for(int i = 0; i < PlayerData.activePlayers.Count; i++)
                 {
                     PlayerController pc = Instantiate(playerPrefab, transform.position, Quaternion.identity);
+                    pc.SetOverheatParameters(overheatParams);
                     pc.SetConfig(PlayerData.activePlayers[i], PlayerController.ControllerState.Gameplay);
                     PlayerInput pi = pc.GetComponent<PlayerInput>();
                     if (PlayerData.activePlayers[i].controlScheme == "KnM")

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerController.cs
@@ -420,6 +420,16 @@ public class PlayerController : MonoBehaviour
                 break;
         }
     }
+
+    public void SetOverheatParameters(OverheatParameters ovh)
+    {
+        if (ovh == null) return;
+        _overheat = new Overheat(ovh.maxShootOverheat, ovh.overheatMax, ovh.heatRemove, ovh.heatAdd);
+        maxShootOverheat = ovh.maxShootOverheat;
+        overheatMax = ovh.overheatMax;
+        heatRemove = ovh.heatRemove;
+        heatAdd = ovh.heatAdd;
+    }
 }
 
 public struct ShotInformation

--- a/80s Game/Assets/Scripts/Overheat/OverheatParameters.cs
+++ b/80s Game/Assets/Scripts/Overheat/OverheatParameters.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName ="ScriptableObjects/OverheatParameters")]
+public class OverheatParameters : ScriptableObject
+{
+    public float overheatMax;
+    public float maxShootOverheat;
+    public float heatAdd;
+    public float heatRemove;
+}

--- a/80s Game/Assets/Scripts/Overheat/OverheatParameters.cs.meta
+++ b/80s Game/Assets/Scripts/Overheat/OverheatParameters.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b399ed9be39fac408ed62015fd13516
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Made it so every game mode can set its own overheat rules
Changes are currently only relevant between classic/competitive and defense

## Please describe how to test
Play the different game modes and in the inspector see how the PlayerController overheat values change.


## Relevant Screenshots
The three stooges
![image](https://github.com/user-attachments/assets/40289048-ee66-459d-82e9-6419fb84ea48)

Classic Mode parameters
![image](https://github.com/user-attachments/assets/47535b4f-24ad-4688-89f1-632509be9c51)


Defense Mode parameters
![image](https://github.com/user-attachments/assets/fbf911a0-da16-45f4-ba15-be7075b2df81)



## Issue worked on
No assigned issue

## What Sprint is this due in?
Sprint 6