### PR TITLE
Controller multi-input on UI fixed

### DIFF
--- a/80s Game/Assets/Scenes/CompetitiveMode.unity
+++ b/80s Game/Assets/Scenes/CompetitiveMode.unity
@@ -5526,17 +5526,17 @@ MonoBehaviour:
   m_MoveRepeatDelay: 0.5
   m_MoveRepeatRate: 0.1
   m_XRTrackingOrigin: {fileID: 0}
-  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_PointAction: {fileID: -2677292166944072511, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_MoveAction: {fileID: 473621817304722309, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_SubmitAction: {fileID: 2624253703710512403, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_CancelAction: {fileID: -6468108997024710708, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_LeftClickAction: {fileID: -5560954059868633267, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_MiddleClickAction: {fileID: 2974216286330282421, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_RightClickAction: {fileID: -926926937704692313, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_ScrollWheelAction: {fileID: 7322619000301279243, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 7420303637548259822, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: -6598059107785011507, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
   m_DeselectOnBackgroundClick: 1
   m_PointerBehavior: 0
   m_CursorLockBehavior: 0

--- a/80s Game/Assets/Scenes/CooperativeMode.unity
+++ b/80s Game/Assets/Scenes/CooperativeMode.unity
@@ -5862,17 +5862,17 @@ MonoBehaviour:
   m_MoveRepeatDelay: 0.5
   m_MoveRepeatRate: 0.1
   m_XRTrackingOrigin: {fileID: 0}
-  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_PointAction: {fileID: -2677292166944072511, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_MoveAction: {fileID: 473621817304722309, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_SubmitAction: {fileID: 2624253703710512403, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_CancelAction: {fileID: -6468108997024710708, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_LeftClickAction: {fileID: -5560954059868633267, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_MiddleClickAction: {fileID: 2974216286330282421, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_RightClickAction: {fileID: -926926937704692313, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_ScrollWheelAction: {fileID: 7322619000301279243, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 7420303637548259822, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: -6598059107785011507, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
   m_DeselectOnBackgroundClick: 1
   m_PointerBehavior: 0
   m_CursorLockBehavior: 0

--- a/80s Game/Assets/Scenes/SampleScene.unity
+++ b/80s Game/Assets/Scenes/SampleScene.unity
@@ -4243,17 +4243,17 @@ MonoBehaviour:
   m_MoveRepeatDelay: 0.5
   m_MoveRepeatRate: 0.1
   m_XRTrackingOrigin: {fileID: 0}
-  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_PointAction: {fileID: -2677292166944072511, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_MoveAction: {fileID: 473621817304722309, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_SubmitAction: {fileID: 2624253703710512403, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_CancelAction: {fileID: -6468108997024710708, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_LeftClickAction: {fileID: -5560954059868633267, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_MiddleClickAction: {fileID: 2974216286330282421, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_RightClickAction: {fileID: -926926937704692313, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_ScrollWheelAction: {fileID: 7322619000301279243, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 7420303637548259822, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: -6598059107785011507, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
   m_DeselectOnBackgroundClick: 1
   m_PointerBehavior: 0
   m_CursorLockBehavior: 0

--- a/80s Game/Assets/Scenes/TitleScreen.unity
+++ b/80s Game/Assets/Scenes/TitleScreen.unity
@@ -1284,6 +1284,7 @@ MonoBehaviour:
   debuffs: []
   selfDebuffs: []
   weightConfig: {fileID: 0}
+  overheatParams: {fileID: 0}
   debug: 1
   spawnConfig: {fileID: 0}
   maxForce: 0.25
@@ -1303,6 +1304,7 @@ MonoBehaviour:
   canvas: {fileID: 319221310}
   modifierContainers: []
   postProcessVolume: {fileID: 2125853500}
+  onboardingUI: {fileID: 0}
   titleScreenUI: {fileID: 319221312}
   scoreBehavior: {fileID: 0}
   backgroundUI: {fileID: 1894973268}
@@ -2053,17 +2055,17 @@ MonoBehaviour:
   m_MoveRepeatDelay: 0.5
   m_MoveRepeatRate: 0.1
   m_XRTrackingOrigin: {fileID: 0}
-  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
-  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_PointAction: {fileID: -2677292166944072511, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_MoveAction: {fileID: 473621817304722309, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_SubmitAction: {fileID: 2624253703710512403, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_CancelAction: {fileID: -6468108997024710708, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_LeftClickAction: {fileID: -5560954059868633267, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_MiddleClickAction: {fileID: 2974216286330282421, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_RightClickAction: {fileID: -926926937704692313, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_ScrollWheelAction: {fileID: 7322619000301279243, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 7420303637548259822, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: -6598059107785011507, guid: 2e5725103ad17b843888d975b30c3b9a, type: 3}
   m_DeselectOnBackgroundClick: 1
   m_PointerBehavior: 0
   m_CursorLockBehavior: 0


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Fixed the controller multi-input bug for d-pad.

The input asset being used for the event system did not match the input asset being used anywhere else, except on the join screen for some reason, which is why double inputs were not found there.

## Please describe how to test
Navigate the UI in the title screen using the d-pad on your controller.
Do the same for the settings menu in Classic, Competitive and Defense.

You should not see any skipping of options

## Relevant Screenshots
Nothing to show

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?assignee=712020%3A72da91bd-2f5a-4c69-861e-59715da3052a&selectedIssue=BB-277

## What Sprint is this due in?
Sprint 6