### PR TITLE
Movement override for collision avoidance movement

### DIFF
--- a/80s Game/Assets/Prefabs/Bonus Bat High.prefab
+++ b/80s Game/Assets/Prefabs/Bonus Bat High.prefab
@@ -9915,6 +9915,7 @@ MonoBehaviour:
   isWandering: 0
   isFleeing: 0
   maxSpeed: 6
+  maxDistance: 15
   currentVelocity: {x: 0, y: 0}
 --- !u!95 &3464643637762033909
 Animator:

--- a/80s Game/Assets/Prefabs/Bonus Bat Low.prefab
+++ b/80s Game/Assets/Prefabs/Bonus Bat Low.prefab
@@ -9915,6 +9915,7 @@ MonoBehaviour:
   isWandering: 0
   isFleeing: 0
   maxSpeed: 6
+  maxDistance: 15
   currentVelocity: {x: 0, y: 0}
 --- !u!95 &3464643637762033909
 Animator:

--- a/80s Game/Assets/Prefabs/DefenseBat.prefab
+++ b/80s Game/Assets/Prefabs/DefenseBat.prefab
@@ -162,6 +162,7 @@ MonoBehaviour:
   isWandering: 0
   isFleeing: 0
   maxSpeed: 6
+  maxDistance: 15
   currentVelocity: {x: 0, y: 0}
 --- !u!95 &5122440697510579374
 Animator:

--- a/80s Game/Assets/Prefabs/DiveBombBat.prefab
+++ b/80s Game/Assets/Prefabs/DiveBombBat.prefab
@@ -165,6 +165,7 @@ MonoBehaviour:
   isWandering: 0
   isFleeing: 0
   maxSpeed: 6
+  maxDistance: 15
   currentVelocity: {x: 0, y: 0}
 --- !u!95 &5122440697510579374
 Animator:

--- a/80s Game/Assets/Prefabs/ModifierBat.prefab
+++ b/80s Game/Assets/Prefabs/ModifierBat.prefab
@@ -165,6 +165,7 @@ MonoBehaviour:
   isWandering: 0
   isFleeing: 0
   maxSpeed: 6
+  maxDistance: 15
   currentVelocity: {x: 0, y: 0}
 --- !u!95 &5122440697510579374
 Animator:

--- a/80s Game/Assets/Prefabs/ModifierDefenseBat.prefab
+++ b/80s Game/Assets/Prefabs/ModifierDefenseBat.prefab
@@ -165,6 +165,7 @@ MonoBehaviour:
   isWandering: 0
   isFleeing: 0
   maxSpeed: 6
+  maxDistance: 15
   currentVelocity: {x: 0, y: 0}
 --- !u!95 &5122440697510579374
 Animator:

--- a/80s Game/Assets/Prefabs/TestTarget.prefab
+++ b/80s Game/Assets/Prefabs/TestTarget.prefab
@@ -162,6 +162,7 @@ MonoBehaviour:
   isWandering: 0
   isFleeing: 0
   maxSpeed: 6
+  maxDistance: 15
   currentVelocity: {x: 0, y: 0}
 --- !u!95 &5122440697510579374
 Animator:

--- a/80s Game/Assets/Prefabs/UnstableDefenseBat.prefab
+++ b/80s Game/Assets/Prefabs/UnstableDefenseBat.prefab
@@ -85,6 +85,7 @@ MonoBehaviour:
   isWandering: 0
   isFleeing: 0
   maxSpeed: 6
+  maxDistance: 15
   currentVelocity: {x: 0, y: 0}
 --- !u!95 &3464643637762033909
 Animator:

--- a/80s Game/Assets/Prefabs/UnstableTarget.prefab
+++ b/80s Game/Assets/Prefabs/UnstableTarget.prefab
@@ -85,6 +85,7 @@ MonoBehaviour:
   isWandering: 0
   isFleeing: 0
   maxSpeed: 6
+  maxDistance: 15
   currentVelocity: {x: 0, y: 0}
 --- !u!95 &3464643637762033909
 Animator:

--- a/80s Game/Assets/Scripts/AI/MovementStrategies/KinematicSteer.cs
+++ b/80s Game/Assets/Scripts/AI/MovementStrategies/KinematicSteer.cs
@@ -13,7 +13,8 @@ public class KinematicSteer : MonoBehaviour
     // Maximums
     [Range(0, 10)]
     public float maxSpeed = 3f;
-
+    [Range(2, 15)]
+    public float maxDistance = 8.0f;
 
     // Private fields for calculations
     public Vector2 currentVelocity;

--- a/80s Game/Assets/Scripts/AI/MovementStrategies/VelocityObstacleAvoidance.cs
+++ b/80s Game/Assets/Scripts/AI/MovementStrategies/VelocityObstacleAvoidance.cs
@@ -1,7 +1,4 @@
-using TMPro;
 using UnityEngine;
-using UnityEngine.UIElements;
-using static UnityEngine.RuleTile.TilingRuleOutput;
 
 public class VelocityObstacleAvoidance : AbsMovementStrategy
 {
@@ -13,7 +10,14 @@ public class VelocityObstacleAvoidance : AbsMovementStrategy
     {
         UpdateVelocity();
         AvoidObstacles();
-        
+        if (DistanceOverride())
+        {
+            
+            Vector3 position = movementController.gameObject.transform.position;
+            Vector2 currentPosition = new Vector2(position.x, position.y);
+            movementController.currentVelocity = (movementController.targetPosition - currentPosition).normalized * movementController.GetMaxSpeed();
+            Debug.DrawLine(currentPosition, currentPosition + movementController.currentVelocity);
+        }
         return UpdatePosition();
         
     }
@@ -138,5 +142,11 @@ public class VelocityObstacleAvoidance : AbsMovementStrategy
         }
         Vector2 whisker = Quaternion.AngleAxis(angle, rotationAngle) * velocity.normalized;
         return whisker.normalized;
+    }
+
+    private bool DistanceOverride()
+    {
+        float distance = Vector2.Distance(movementController.targetPosition, movementController.gameObject.transform.position);
+        return distance > movementController.maxDistance;
     }
 }


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Creatures that are too far away from their objectives have their movement overriden so they bee-line towards their target. Collision avoidance should kick in once on-screen.

## Please describe how to test
Play Defense.
There should never be bats that are miles away from the viewport.

## Relevant Screenshots


## Issue worked on
No issue

## What Sprint is this due in?
Post production