### PR TITLE
Zero sensitivity issue fixed

### DIFF
--- a/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
@@ -29,7 +29,7 @@ public class PlayerJoinManager : MonoBehaviour
     private int backOutPlayerRef;
     private bool controllerConnected;
     private bool sceneTransition = false;
-
+    private float defaultSensitivity = 4.0f;
 
     private void Awake()
     {
@@ -51,6 +51,10 @@ public class PlayerJoinManager : MonoBehaviour
         // We then instantiate a Player Panel to allow players to set their preferences for gameplay and alter the control scheme accordingly.
         GameObject newPlayerPanel = Instantiate(joinPanelPrefab, joinPanelContainer.transform);
         playerInput.SwitchCurrentActionMap("UI");
+
+        // To avoid the 0-sensitivity bug, we begin by defining a sensitivity value that might get overriden later
+        // Sensitivity values change by input, so we begin by detecting input type
+        string currentControlScheme = playerInput.currentControlScheme;
         
         // We then create a data object that will persist player's information from the join scene to the gameplay scene
         PlayerConfig config = new PlayerConfig(playerInput.playerIndex, PlayerData.defaultColors[playerInput.playerIndex], new Vector2(2.5f,2.5f));
@@ -64,7 +68,13 @@ public class PlayerJoinManager : MonoBehaviour
 
         // Set back sensitivity override if this is player one
         if(playerInput.playerIndex == 0)
-            config.sensitivity = new Vector2(PlayerPrefs.GetFloat("Sensitivity"), PlayerPrefs.GetFloat("Sensitivity"));
+        {
+            config.sensitivity = new Vector2(PlayerPrefs.GetFloat("Sensitivity", defaultSensitivity), PlayerPrefs.GetFloat("Sensitivity", defaultSensitivity));
+        } else
+        {
+            config.sensitivity = new Vector2(defaultSensitivity, defaultSensitivity);
+        }
+            
         PlayerData.activePlayers.Add(config);
         pc.SetConfig(config, PlayerController.ControllerState.JoinScreen);
         pc.SetJoinManager(this);
@@ -81,7 +91,7 @@ public class PlayerJoinManager : MonoBehaviour
         //Change Prompt Tray Icons based on which control scheme Player 1 uses
         if (pc.Order == 0)
         {
-            switch (playerInput.currentControlScheme)
+            switch (currentControlScheme)
             {
                 case "KnM":
                     ChangePromptTray(keyboardInputPrompts, false);


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Fixed the situation where people playing a fresh game get no sensitivity during play and have to go into the settings menu to fix that.

## Please describe how to test
Clear player prefs
Start a game without touching sensitivity
It should work fine in both controller and mouse

## Relevant Screenshots


## Issue worked on


## What Sprint is this due in?
