### PR TITLE
Added timeDelta to sensitivity

### DIFF
--- a/80s Game/Assets/PlayerInput/InputActions.inputactions
+++ b/80s Game/Assets/PlayerInput/InputActions.inputactions
@@ -222,17 +222,6 @@
                 },
                 {
                     "name": "",
-                    "id": "0cc735a6-d948-4c5a-9607-5e317b0d70da",
-                    "path": "<Gamepad>/buttonSouth",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "PS4;xbox",
-                    "action": "Recenter",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
                     "id": "6e8af115-8cb3-4762-8716-2acb31b1ed96",
                     "path": "<Gamepad>/buttonEast",
                     "interactions": "",

--- a/80s Game/Assets/Scripts/Multiplayer/InputData.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/InputData.cs
@@ -1,0 +1,4 @@
+public class InputData
+{
+
+}

--- a/80s Game/Assets/Scripts/Multiplayer/InputData.cs.meta
+++ b/80s Game/Assets/Scripts/Multiplayer/InputData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8dcc98457ca67f45a90de114a58d7fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerJoinManager.cs
@@ -29,7 +29,8 @@ public class PlayerJoinManager : MonoBehaviour
     private int backOutPlayerRef;
     private bool controllerConnected;
     private bool sceneTransition = false;
-    private float defaultSensitivity = 4.0f;
+    private float defaultSensitivity = 4.5f;
+    private float mouseDefaultSensitivity = 2.5f;
 
     private void Awake()
     {
@@ -55,6 +56,11 @@ public class PlayerJoinManager : MonoBehaviour
         // To avoid the 0-sensitivity bug, we begin by defining a sensitivity value that might get overriden later
         // Sensitivity values change by input, so we begin by detecting input type
         string currentControlScheme = playerInput.currentControlScheme;
+        float defaultDeviceSensitivity = defaultSensitivity;
+        if(currentControlScheme == "KnM")
+        {
+            defaultDeviceSensitivity = mouseDefaultSensitivity;
+        }
         
         // We then create a data object that will persist player's information from the join scene to the gameplay scene
         PlayerConfig config = new PlayerConfig(playerInput.playerIndex, PlayerData.defaultColors[playerInput.playerIndex], new Vector2(2.5f,2.5f));
@@ -69,7 +75,7 @@ public class PlayerJoinManager : MonoBehaviour
         // Set back sensitivity override if this is player one
         if(playerInput.playerIndex == 0)
         {
-            config.sensitivity = new Vector2(PlayerPrefs.GetFloat("Sensitivity", defaultSensitivity), PlayerPrefs.GetFloat("Sensitivity", defaultSensitivity));
+            config.sensitivity = new Vector2(PlayerPrefs.GetFloat("Sensitivity", defaultDeviceSensitivity), PlayerPrefs.GetFloat("Sensitivity", defaultDeviceSensitivity));
         } else
         {
             config.sensitivity = new Vector2(defaultSensitivity, defaultSensitivity);

--- a/80s Game/Assets/Scripts/UI Scripts/Crosshair.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/Crosshair.cs
@@ -48,8 +48,8 @@ public class Crosshair : MonoBehaviour
             overheatUI.color = Color.Lerp(startColor, endColor, Mathf.Sin(jiggleFrequency * currentJiggleTimer * 0.5f) * 0.5f + 0.5f);
         }
 
-        float finalX = transform.position.x + movementDelta.x + jiggleOffsetX;
-        float finalY = transform.position.y + movementDelta.y + jiggleOffsetY;
+        float finalX = transform.position.x + movementDelta.x + jiggleOffsetX * Time.deltaTime;
+        float finalY = transform.position.y + movementDelta.y + jiggleOffsetY * Time.deltaTime;
         Vector3 newPosition = Clamp(new Vector3(finalX, finalY, transform.position.z));
         transform.position = newPosition;
     }


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
timeDelta was not a part of the calculations for cursor sensitivity
Also, removed the Recenter input

## Please describe how to test
Pull, build.
Windows registry - delete Yesteryear Games/Bat Bots
Play with mouse
Windows registry - delete Yesteryear Games/Bat Bots
Play with controller

Report on sensitivity feeling ok.

## Relevant Screenshots


## Issue worked on


## What Sprint is this due in?
