### PR TITLE
Show Accuracy Between Rounds (with Bonus Points)

### DIFF
--- a/80s Game/Assets/Animations/AccuracyText.anim
+++ b/80s Game/Assets/Animations/AccuracyText.anim
@@ -1,0 +1,249 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AccuracyText
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.5
+        value: {x: 2.5, y: 2.5, z: 2.5}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 2.0166667
+        value: {x: 2.5, y: 2.5, z: 2.5}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 2.5
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: 
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 3
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 2.5
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 2.5
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.0166667
+        value: 2.5
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.5
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.x
+    path: 
+    classID: 224
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 2.5
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.0166667
+        value: 2.5
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.5
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.y
+    path: 
+    classID: 224
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 2.5
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.0166667
+        value: 2.5
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.5
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.z
+    path: 
+    classID: 224
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/80s Game/Assets/Animations/AccuracyText.anim.meta
+++ b/80s Game/Assets/Animations/AccuracyText.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bec225e94bb77df48924366b0203c2f3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/80s Game/Assets/Animations/NewRoundIndicator.controller
+++ b/80s Game/Assets/Animations/NewRoundIndicator.controller
@@ -12,6 +12,9 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: 2442150918132744980}
     m_Position: {x: 290, y: 100, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -2128526774534910111}
+    m_Position: {x: 325, y: 165, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -21,7 +24,33 @@ AnimatorStateMachine:
   m_EntryPosition: {x: 50, y: 120, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 2442150918132744980}
+  m_DefaultState: {fileID: -2128526774534910111}
+--- !u!1102 &-2128526774534910111
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AccuracyText
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: bec225e94bb77df48924366b0203c2f3, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -36,7 +65,7 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/80s Game/Assets/Prefabs/Floating Text/FloatingTextAccuracy.prefab
+++ b/80s Game/Assets/Prefabs/Floating Text/FloatingTextAccuracy.prefab
@@ -13,8 +13,9 @@ GameObject:
   - component: {fileID: 663682550276029941}
   - component: {fileID: 4277385306347250861}
   - component: {fileID: 3433382152933106016}
+  - component: {fileID: 2223417870976913635}
   m_Layer: 0
-  m_Name: FloatingTextNewRound
+  m_Name: FloatingTextAccuracy
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -36,7 +37,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
   m_SizeDelta: {x: 672.19, y: 284.29}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!23 &6677236986545228302
@@ -101,7 +102,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: NEW ROUND
+  m_text: 'Accuracy:'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
   m_sharedMaterial: {fileID: -507269567956872517, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
@@ -207,3 +208,17 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &2223417870976913635
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5422266768498237442}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa6354f61b0697641941297fdd4a62ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  accuracy: 0
+  bonusPoints: 0

--- a/80s Game/Assets/Prefabs/Floating Text/FloatingTextAccuracy.prefab.meta
+++ b/80s Game/Assets/Prefabs/Floating Text/FloatingTextAccuracy.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e6e18e1c06e0c9c4eb1332faf76aa60a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/80s Game/Assets/Scenes/SampleScene.unity
+++ b/80s Game/Assets/Scenes/SampleScene.unity
@@ -4975,6 +4975,8 @@ MonoBehaviour:
   coreHealthPercentage: {fileID: 0}
   core: {fileID: 0}
   newRoundTextPrefab: {fileID: 5422266768498237442, guid: fb3e11995eab6b44dbde8bef1e940d3d, type: 3}
+  accuracyTextPrefab: {fileID: 5422266768498237442, guid: e6e18e1c06e0c9c4eb1332faf76aa60a, type: 3}
+  bonusPoints: 0
 --- !u!114 &1011990667
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5391,6 +5393,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: aedf6b149ca39fa4b8f75744e6f88757, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  gameLanguage: 0
 --- !u!1 &1107327210
 GameObject:
   m_ObjectHideFlags: 0

--- a/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/ClassicMode.cs
@@ -192,6 +192,7 @@ public class ClassicMode : AbsGameMode
                 if (GameManager.Instance.roundEndTheme != null)
                     SoundManager.Instance.PlaySoundContinuous(GameManager.Instance.roundEndTheme.Clip);
                 GameManager.Instance.UIManager.scoreBehavior.ShowNewRoundText();
+                GameManager.Instance.UIManager.scoreBehavior.ShowAccuracy();
                 GameManager.Instance.StartRoundDelay();
             }
                 

--- a/80s Game/Assets/Scripts/PointsManager.cs
+++ b/80s Game/Assets/Scripts/PointsManager.cs
@@ -67,6 +67,7 @@ public class PointsManager : MonoBehaviour
         }
         int numBonusPoints = Mathf.RoundToInt(RoundScoreByPlayer[player] * accuracy);
         
+        scoreBehavior.bonusPoints = numBonusPoints;
         scoreBehavior.UpdateScores(player);
         scoreBehavior.UpdateAccuracy(accuracy);
         Debug.Log("Updated accuracy: " + accuracy);

--- a/80s Game/Assets/Scripts/UI Scripts/AccuracyText.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/AccuracyText.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+public class AccuracyText : MonoBehaviour
+{
+    public float accuracy;
+    public float bonusPoints;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        this.GetComponent<TextMeshPro>().text = "Accuracy: " + accuracy.ToString("F0") + "%\n +" + bonusPoints.ToString("F0") + " Pts";
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/80s Game/Assets/Scripts/UI Scripts/AccuracyText.cs.meta
+++ b/80s Game/Assets/Scripts/UI Scripts/AccuracyText.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa6354f61b0697641941297fdd4a62ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/80s Game/Assets/Scripts/UI Scripts/ScoreBehavior.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/ScoreBehavior.cs
@@ -40,6 +40,8 @@ public class ScoreBehavior : MonoBehaviour
     public Defendable core;   
 
     public GameObject newRoundTextPrefab;
+    public GameObject accuracyTextPrefab;
+    public float bonusPoints;
 
     // Start is called before the first frame update
     void Start()
@@ -270,5 +272,13 @@ public class ScoreBehavior : MonoBehaviour
     public void ShowNewRoundText()
     {
         Instantiate(newRoundTextPrefab, newRoundTextPrefab.transform.position, Quaternion.identity);
+    }
+
+    //Show text to indicate accuracy and points gained
+    public void ShowAccuracy()
+    {
+        GameObject accText = Instantiate(accuracyTextPrefab, accuracyTextPrefab.transform.position, Quaternion.identity);
+        accText.GetComponent<AccuracyText>().accuracy = accuracy;
+        accText.GetComponent<AccuracyText>().bonusPoints = bonusPoints;
     }
 }


### PR DESCRIPTION
## Summarize what is being added
-Accuracy is now shown in between games as well as the bonus points awarded for accuracy

## Please describe how to test
-Play classic mode, the text in between rounds should last longer and show the current accuracy as well as the bonus points awarded from accuracy that round

## Issue worked on

## What Sprint is this due in?
