### PR TITLE
Fixing infinite round bug on defense.

### DIFF
--- a/80s Game/Assets/Scripts/GameModes/CompetitiveMode.cs
+++ b/80s Game/Assets/Scripts/GameModes/CompetitiveMode.cs
@@ -2,9 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEngine;
-using UnityEngine.InputSystem;
-using UnityEngine.SocialPlatforms.Impl;
 
 public class CompetitiveMode : AbsGameMode
 {

--- a/80s Game/Assets/Scripts/TargetManager.cs
+++ b/80s Game/Assets/Scripts/TargetManager.cs
@@ -207,13 +207,21 @@ public class TargetManager : MonoBehaviour
 
     public int RegisterActiveTarget(Target target)
     {
-        activeTargets.Add(target);
+        if (!activeTargets.Contains(target))
+        {
+            activeTargets.Add(target);
+        }
         return activeTargets.Count - 1;
     }
 
     public void RemoveActiveTarget(Target target)
     {
-        activeTargets.Remove(target);
+        bool removal = activeTargets.Remove(target);
+        if (!removal)
+        {
+            string errorString = string.Format("Removal error! Target {0} not removed", target);
+            Debug.LogError(errorString);
+        }
     }
 
     /* Debug Methods */


### PR DESCRIPTION
<!---
Pull request template for Bat Bots. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
Addressed the issue causing rounds to go on forever without bats active on screen for defense mode.
Competitive and Classic also working as intended

## Please describe how to test
Play defense mode as long as you can
When you kill all bats on screen, rounds should transition normally.

## Relevant Screenshots


## Issue worked on


## What Sprint is this due in?
Release build