### PR TITLE
Fixed Zero Sensitivity Bug

### DIFF
--- a/80s Game/Assets/Scenes/TitleScreen.unity
+++ b/80s Game/Assets/Scenes/TitleScreen.unity
@@ -581,7 +581,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: v. 1.0.4
+  m_text: v. 1.0.5
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 4ffe7c97efad09e458ea5fc5958a4597, type: 2}
   m_sharedMaterial: {fileID: -507269567956872517, guid: 84b0cb86ea878a1418876046345b0f8e, type: 2}

--- a/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
+++ b/80s Game/Assets/Scripts/Multiplayer/PlayerInputWrapper.cs
@@ -96,6 +96,7 @@ public class PlayerInputWrapper : MonoBehaviour
         {
             snailModifier = 0.5f;
         }
+
         Vector2 scalingVector = sensitivity * config.sensitivity * snailModifier * Time.deltaTime;
         Vector2 input = value.Get<Vector2>();
         if (!controllerInput)

--- a/80s Game/Assets/Scripts/UI Scripts/SettingsManager.cs
+++ b/80s Game/Assets/Scripts/UI Scripts/SettingsManager.cs
@@ -67,6 +67,7 @@ public class SettingsManager : MonoBehaviour
         playerIndex = -1;
 
         //Load in the settings from PlayerPrefs
+        sensitivityValue = PlayerPrefs.GetFloat("Sensitivity", 3.25f);
         LoadSettings();
     }
 
@@ -135,8 +136,6 @@ public class SettingsManager : MonoBehaviour
             EventSystem.current.SetSelectedGameObject(sfxVolumeSlider.gameObject);
 
             StorePreviousSensitivity(playerIndex);
-            Debug.Log(tempSensitivity);
-
             settingsApplied = false;
 
             //Change input prompts for changing tabs based on the control scheme of the player who paused
@@ -177,13 +176,13 @@ public class SettingsManager : MonoBehaviour
     //Save the settings, then close the menu
     public void ApplySettings()
     {
+
         PlayerPrefs.SetFloat("MusicVolume", musicVolumeSlider.value);
         PlayerPrefs.SetFloat("SFXVolume", sfxVolumeSlider.value);
         PlayerPrefs.SetFloat("Sensitivity", sensitivityValue);
         PlayerPrefs.SetInt("Bloom", System.Convert.ToInt32(bloomToggle.isOn));
         PlayerPrefs.SetInt("CRTOn", System.Convert.ToInt32(crtToggle.isOn));
         PlayerPrefs.SetFloat("CRTCurvature", crtCurvature.value);
-
         settingsApplied = true;
 
         ToggleSettingsPanel();


### PR DESCRIPTION
## Summarize what is being added
-Fixed the infamous zero sensitivity bug

## Please describe how to test
-Start a game of any mode, make sure you're Sensitivity is what you want it to be.
-Quit to the Title Screen and open the Settings Menu. Apply Settings WITHOUT touching the sensitivity slider
-Boot up a game like normal, Sensitivity should not be set to 0

## Issue worked on
https://bat-bots.atlassian.net/jira/software/projects/BB/boards/1?selectedIssue=BB-353

## What Sprint is this due in?
v.1.0.5